### PR TITLE
feat: improve skill scores for lfgtm

### DIFF
--- a/skills/battlecard/SKILL.md
+++ b/skills/battlecard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: battlecard
-description: Generate competitive battlecards, displacement campaigns, trap questions, and objection counters as text-based analysis grounded in library data and real deal evidence. Use when user says "battlecard for [competitor]", "how do we beat [competitor]", "competitive intel", "trap questions", "displacement campaign", or mentions competing against a rival. Do NOT use for visual HTML battlecard documents — use /octave:battlecard-doc instead.
+description: "Generate competitive battlecards, displacement campaigns, trap questions, and objection counters as text-based analysis grounded in library data and real deal evidence. Use when user says 'battlecard for [competitor]', 'how do we beat [competitor]', 'competitive intel', 'trap questions', 'displacement campaign', or mentions competing against a rival. Do NOT use for visual HTML battlecard documents — use /octave:battlecard-doc instead."
 ---
 
 # /octave:battlecard - Competitive War Room
@@ -15,58 +15,29 @@ Dedicated competitive intelligence skill that generates living competitive artif
 
 ## Modes
 
-```
-/octave:battlecard                                        # Interactive - pick competitor and mode
-/octave:battlecard battlecard --competitor "Acme"         # Full competitive battlecard
-/octave:battlecard displacement --competitor "Acme"       # Displacement campaign
-/octave:battlecard traps --competitor "Acme"              # Trap questions to expose weaknesses
-/octave:battlecard objections --competitor "Acme"         # "They say X, we say Y" guide
-/octave:battlecard compare --competitor "Acme"            # Side-by-side comparison
-/octave:battlecard landscape                              # Full competitive landscape overview
-```
+| Mode | Command | Description |
+|------|---------|-------------|
+| Interactive | `/octave:battlecard` | Pick competitor and mode |
+| Full Battlecard | `/octave:battlecard battlecard --competitor "Acme"` | Comprehensive positioning guide for sales |
+| Displacement | `/octave:battlecard displacement --competitor "Acme"` | Outreach campaign to win their customers |
+| Traps | `/octave:battlecard traps --competitor "Acme"` | Discovery questions exposing weaknesses |
+| Objections | `/octave:battlecard objections --competitor "Acme"` | "They say X, we say Y" paired responses |
+| Compare | `/octave:battlecard compare --competitor "Acme"` | Side-by-side feature/capability comparison |
+| Landscape | `/octave:battlecard landscape` | Full competitive landscape overview |
 
 ## Instructions
 
-When the user runs `/octave:battlecard`:
-
 ### Step 1: Identify Competitor and Mode
 
-If no competitor specified, list available competitors:
+If no competitor specified, fetch available competitors:
 
 ```
-# Get all competitors
 list_all_entities({ entityType: "competitor" })
 ```
 
-Present:
-```
-Which competitor are you focused on?
+Present a numbered list of competitors from the library, plus options to research a new competitor or view the full landscape.
 
-COMPETITORS IN YOUR LIBRARY
-1. [Competitor 1] - [Brief description]
-2. [Competitor 2] - [Brief description]
-3. [Competitor 3] - [Brief description]
-
-OTHER
-4. Research a new competitor (provide name/domain)
-5. Full competitive landscape (all competitors)
-
-Your choice:
-```
-
-If no mode specified, ask:
-```
-What do you need?
-
-1. Full Battlecard - Comprehensive positioning guide for sales
-2. Displacement Campaign - Outreach to steal their customers
-3. Trap Questions - Discovery questions that expose their weaknesses
-4. Objection Counters - "They say X, we say Y" paired responses
-5. Side-by-Side Compare - Feature/capability comparison
-6. Competitive Landscape - Overview of all competitors
-
-Your choice:
-```
+If no mode specified, present the six modes listed above and ask the user to choose.
 
 ### Step 2: Gather Competitive Intelligence
 
@@ -121,439 +92,42 @@ list_all_entities({ entityType: "product" })
 get_entity({ oId: "<product_oId>" })
 ```
 
+#### Validation Checkpoint
+
+Before generating output, verify data sufficiency:
+
+- **Minimum sources**: At least 2 data sources returned results (competitor entity, playbook, proof points, findings, or deal events). If fewer than 2 sources returned data, warn the user: "Limited competitive data available — output will rely on [available source]. Consider enriching your library with `/octave:library create competitor` for richer results."
+- **Deal data gap**: If no win/loss events exist, note: "No deal outcome data found. Battlecard will be built from library positioning and conversation data only."
+- **Stale data**: If the most recent finding or event is older than 90 days, flag: "Most recent competitive data is from [date]. Consider refreshing with recent deal outcomes."
+
 ### Step 3: Generate Mode-Specific Output
 
----
-
-#### Mode: Full Battlecard
-
-```
-BATTLECARD: [Your Product] vs [Competitor]
-==========================================
-
-Last Updated: [Date]
-Based on: [N] deal outcomes, [N] conversation mentions
-
----
-
-QUICK POSITIONING
------------------
-When you hear: "[Competitor name]"
-Lead with: "[Key differentiator in one sentence]"
-
-30-Second Pitch:
-"[Elevator pitch that positions against this competitor]"
-
----
-
-COMPETITOR OVERVIEW
--------------------
-What they do: [Brief description from library]
-Target market: [Their focus]
-Pricing: [If known]
-Key customers: [Notable logos]
-Recent moves: [Latest news, features, funding]
-
----
-
-WHERE WE WIN
-------------
-| Capability | Us | Them |
-|------------|-----|------|
-| [Area 1] | ✓ [Our strength] | ✗ [Their weakness] |
-| [Area 2] | ✓ [Our strength] | ~ [Partial/weaker] |
-| [Area 3] | ✓ [Our strength] | ✗ [Their gap] |
-
-Win Themes (from real deals):
-1. [Theme 1] — "[Evidence from conversation data]"
-2. [Theme 2] — "[Evidence from conversation data]"
-3. [Theme 3] — "[Evidence from conversation data]"
-
----
-
-WHERE THEY WIN (BE HONEST)
---------------------------
-| Capability | Them | Our Response |
-|------------|------|-------------|
-| [Area] | ✓ [Their strength] | [How we counter/reframe] |
-
-How to handle:
-• "[Their advantage]" → "[Reframe that shifts the conversation]"
-
----
-
-COMMON OBJECTIONS
------------------
-
-"[Competitor] is cheaper"
-→ [Response: value, TCO, hidden costs, proof point]
-
-"[Competitor] has [feature X]"
-→ [Response: why it matters/doesn't, our alternative approach]
-
-"We already use [Competitor]"
-→ [Displacement angle: migration story, switching cost offset]
-
-"[Competitor] has more [integrations/customers/etc.]"
-→ [Response: quality vs quantity, specific advantage]
-
-Evidence: [Cite real objections from conversation data if available]
-
----
-
-TRAP QUESTIONS
---------------
-Ask these to expose their weaknesses:
-
-1. "[Question targeting known weakness]"
-   Why: [What this reveals]
-   If they say: "[Likely response]" → You say: "[Follow-up]"
-
-2. "[Question about scalability/support/depth]"
-   Why: [What this reveals]
-
-3. "[Question about specific capability gap]"
-   Why: [What this reveals]
-
----
-
-LANDMINES TO SET
-----------------
-Plant these criteria early in the evaluation:
-
-1. "[Evaluation criterion]" — plays to our strength in [area]
-2. "[Technical requirement]" — exposes their limitation in [area]
-3. "[Process question]" — highlights our advantage in [area]
-
----
-
-PROOF POINTS
-------------
-• [Customer who switched from competitor] — [Outcome]
-• [Metric: "X% better than [competitor] in Y"]
-• [Industry analyst or review quote]
-• [Head-to-head evaluation win]
-
----
-
-DISPLACEMENT SUCCESS STORY
----------------------------
-[Customer] switched from [Competitor] because:
-• [Reason 1]
-• [Reason 2]
-Results after switching:
-• [Metric improvement]
-• [Time saved / value gained]
-
----
-
-DEAL WIN/LOSS PATTERNS
------------------------
-Wins against [Competitor]: [N] in last 180 days
-Losses to [Competitor]: [N] in last 180 days
-Win Rate: [X%]
-
-Common win factors:
-• [Factor 1]
-• [Factor 2]
-
-Common loss factors:
-• [Factor 1]
-• [Factor 2]
-
----
-
-Sources Used:
-- Competitor entity: [name]
-- Deals analyzed: [N] wins, [N] losses
-- Conversation mentions: [N]
-- Proof points: [list]
-- Playbooks: [list]
-
----
-
-Want me to:
-1. Deep dive on a specific objection
-2. Generate displacement outreach
-3. Create persona-specific version
-4. Add more trap questions
-5. Update the competitor entity with new insights
-```
-
----
-
-#### Mode: Displacement Campaign
-
-```
-generate_email({
-  person: { firstName: "[Persona Name]", jobTitle: "[Persona Title]" },
-  numEmails: 4,
-  sequenceType: "COLD_OUTBOUND",
-  allEmailsContext: "This person currently uses [Competitor]. Key competitor weaknesses: [list]. Our advantages: [list]. Proof of successful switches: [proof points]. Do NOT name the competitor unless the prospect mentions them first.",
-  allEmailsInstructions: "Displacement campaign. Progressive structure: Email 1: Pain-point their current tool likely causes. Email 2: Vision of what's possible (results from switchers). Email 3: Specific differentiation without naming competitor. Email 4: Direct offer with migration support."
-})
-```
-
-Present as:
-```
-DISPLACEMENT CAMPAIGN: [Your Product] vs [Competitor]
-=====================================================
-
-Target: [Persona] currently using [Competitor]
-Strategy: [Lead with pain, prove with results, close with support]
-
----
-
-POSITIONING STRATEGY
---------------------
-Don't lead with: "[Competitor] is bad"
-Lead with: "[Pain they're likely experiencing because of competitor limitations]"
-
-Key angles:
-1. [Pain point caused by competitor weakness]
-2. [Results achieved by companies who switched]
-3. [Capability they're missing]
-
----
-
-EMAIL 1: [Subject]
-Timing: Day 1 | Angle: Pain recognition
----
-[Email body]
-
-EMAIL 2: [Subject]
-Timing: Day 4 | Angle: Social proof from switchers
----
-[Email body]
-
-EMAIL 3: [Subject]
-Timing: Day 8 | Angle: Differentiation
----
-[Email body]
-
-EMAIL 4: [Subject]
-Timing: Day 12 | Angle: Migration offer
----
-[Email body]
-
----
-
-LINKEDIN COMPANION MESSAGES
-----------------------------
-Connection note: [Short message]
-Follow-up: [After connection]
-
----
-
-TALK TRACK (if they respond)
------------------------------
-Opening: "[How to start the conversation]"
-Discovery: "[Questions to understand their pain with current tool]"
-Transition: "[How to introduce your solution]"
-Close: "[Specific next step to offer]"
-
----
-
-Sources: [Competitor entity, proof points, deal data]
-```
-
----
-
-#### Mode: Trap Questions
-
-```
-TRAP QUESTIONS: vs [Competitor]
-================================
-
-Use these discovery questions to expose [Competitor]'s weaknesses
-without mentioning them directly.
-
----
-
-QUESTION 1: [Area of weakness]
-"[Natural discovery question]"
-
-Why this works: [Competitor] struggles with [X], so their answer reveals gaps.
-If they say "[typical response]": Follow up with "[deeper question]"
-Our advantage: [What we do better here]
-
----
-
-QUESTION 2: [Area of weakness]
-"[Natural discovery question]"
-
-Why this works: [Explanation]
-If they say "[typical response]": Follow up with "[deeper question]"
-Our advantage: [What we do better]
-
----
-
-[Continue for 5-8 questions]
-
----
-
-SEQUENCING ADVICE
------------------
-Ask in this order for maximum impact:
-1. [Question N] — establishes [criterion] as important
-2. [Question N] — builds on first, reveals gap
-3. [Question N] — introduces area where we dominate
-
----
-
-Sources: [Competitor weaknesses, deal win patterns, conversation data]
-```
-
----
-
-#### Mode: Objection Counters
-
-```
-OBJECTION COUNTERS: vs [Competitor]
-====================================
-
-PRICING OBJECTIONS
-------------------
-
-"[Competitor] is cheaper"
-→ [Response with TCO analysis, value framing]
-  Proof: "[Customer quote or metric]"
-
-"We don't have budget to switch"
-→ [Response about migration support, ROI timeline]
-  Proof: "[Switching ROI proof point]"
-
----
-
-FEATURE OBJECTIONS
-------------------
-
-"[Competitor] has [Feature X]"
-→ [Response: our approach, why ours is better/different]
-  Proof: "[Evidence]"
-
-"[Competitor] integrates with [Tool Y]"
-→ [Response about our integrations or API]
-  Proof: "[Evidence]"
-
----
-
-RELATIONSHIP OBJECTIONS
------------------------
-
-"We've been with [Competitor] for years"
-→ [Response: switching cost vs. opportunity cost]
-  Proof: "[Long-time customer who finally switched]"
-
-"Our team knows [Competitor]"
-→ [Response: onboarding experience, time to value]
-  Proof: "[Evidence]"
-
----
-
-RISK OBJECTIONS
----------------
-
-"Switching is too risky"
-→ [Response: migration support, phased approach]
-  Proof: "[Smooth migration story]"
-
----
-
-FROM REAL CONVERSATIONS
------------------------
-[If conversation data available, cite actual objections heard and what worked]
-
-• "[Real objection from call]" — Handled by: [rep name/approach] — Outcome: [won/lost]
-
----
-
-Sources: [Competitor entity, conversation findings, deal outcomes]
-```
-
----
-
-#### Mode: Side-by-Side Compare
-
-```
-COMPARISON: [Your Product] vs [Competitor]
-==========================================
-
-| Category | [Your Product] | [Competitor] |
-|----------|---------------|-------------|
-| [Category 1] | [Our capability] | [Their capability] |
-| [Category 2] | [Our capability] | [Their capability] |
-| [Category 3] | [Our capability] | [Their capability] |
-| ... | ... | ... |
-
-DETAILED COMPARISON
--------------------
-
-[Category 1]: [Category Name]
-Us: [Detailed description of our approach]
-Them: [Detailed description of their approach]
-Verdict: [Where each wins and why it matters]
-
-[Repeat for each major category]
-
----
-
-SUMMARY
--------
-Choose [Your Product] when: [Scenarios where you win]
-[Competitor] may be better when: [Be honest about their strengths]
-
----
-
-Sources: [Competitor entity, product entity, proof points]
-```
-
----
-
-#### Mode: Competitive Landscape
-
-```
-COMPETITIVE LANDSCAPE
-=====================
-
-[Fetch all competitors and generate overview]
-
-MARKET MAP
-----------
-| Competitor | Focus | Threat Level | Our Win Rate |
-|-----------|-------|-------------|-------------|
-| [Comp 1] | [Focus] | [High/Med/Low] | [X%] |
-| [Comp 2] | [Focus] | [High/Med/Low] | [X%] |
-| [Comp 3] | [Focus] | [High/Med/Low] | [X%] |
-
-KEY THEMES
-----------
-• [Common competitive dynamic 1]
-• [Common competitive dynamic 2]
-• [Market trend affecting competition]
-
-PER-COMPETITOR SNAPSHOT
------------------------
-[Short battlecard summary for each competitor]
-
----
-
-Want me to deep-dive on any competitor?
-```
+Select the appropriate output format based on the chosen mode. Full output templates with complete structural skeletons are provided in the reference files below.
+
+| Mode | Template Reference | Key Sections |
+|------|-------------------|--------------|
+| **Full Battlecard** | [full-battlecard-template.md](references/full-battlecard-template.md) | Quick positioning, where we win/lose, objections, trap questions, landmines, proof points, win/loss patterns |
+| **Displacement** | [displacement-template.md](references/displacement-template.md) | Positioning strategy, 4-email sequence via `generate_email()`, LinkedIn messages, talk track |
+| **Traps** | [traps-template.md](references/traps-template.md) | 5-8 discovery questions with "why this works" rationale and sequencing advice |
+| **Objections** | [objections-template.md](references/objections-template.md) | Pricing, feature, relationship, and risk objection categories with proof points |
+| **Compare** | [compare-template.md](references/compare-template.md) | Feature comparison table, detailed per-category analysis, honest summary |
+| **Landscape** | [landscape-template.md](references/landscape-template.md) | Market map table, key themes, per-competitor snapshots |
+
+**Key principles for all modes:**
+- Ground every claim in library data — cite proof points, deal evidence, and conversation findings
+- Be honest about competitor strengths (builds credibility with sales teams)
+- Include source attribution at the end of each output
+- Use `generate_email()` for displacement email content; use `generate_content()` or write directly for other modes
 
 ### Step 4: Offer Follow-Up Actions
 
-```
-What would you like to do next?
-
-1. Deep dive on a specific area
-2. Generate displacement outreach for a specific person
-3. Create a persona-specific version
-4. Re-generate any piece using a saved agent
-5. Update competitor entity with new insights
-6. Share with team (export)
-7. Done
-```
+After delivering any mode's output, offer these next steps:
+- Deep dive on a specific area
+- Generate displacement outreach for a specific person
+- Create a persona-specific version
+- Re-generate using a saved agent
+- Update competitor entity with new insights
+- Export/share with team
 
 ## Generation Mode Note
 
@@ -566,48 +140,32 @@ For the full interactive mode selector, use `/octave:generate`.
 ## MCP Tools Used
 
 ### Competitive Intelligence
-- `list_all_entities` (competitor) - List all competitors
-- `get_entity` - Get competitor details
-- `search_knowledge_base` - Find competitive positioning, proof points
-- `list_findings` - Real conversation mentions and objections
-- `list_events` - Deal win/loss data against competitor
-- `get_event_detail` - Deep dive into specific competitive deals
+- `list_all_entities` (competitor) — List all competitors
+- `get_entity` — Get competitor details
+- `search_knowledge_base` — Find competitive positioning, proof points
+- `list_findings` — Real conversation mentions and objections
+- `list_events` — Deal win/loss data against competitor
+- `get_event_detail` — Deep dive into specific competitive deals
 
 ### Library Context
-- `get_playbook` - Competitive playbooks and value props
-- `list_value_props` - Value propositions per persona
-- `get_entity` (product) - Product capabilities for comparison
+- `get_playbook` — Competitive playbooks and value props
+- `list_value_props` — Value propositions per persona
+- `get_entity` (product) — Product capabilities for comparison
 
 ### Content Generation
-- `generate_email` - Displacement email campaigns
-- `generate_content` - Trap questions, objection guides, comparisons
+- `generate_email` — Displacement email campaigns
+- `generate_content` — Trap questions, objection guides, comparisons
 
 ## Error Handling
 
-**No Competitors in Library:**
-> No competitors found in your library.
->
-> Options:
-> 1. Add a competitor first: `/octave:library create competitor`
-> 2. Tell me the competitor name and I'll create a basic comparison
-
-**No Deal Data:**
-> No win/loss data found against [Competitor].
->
-> I'll build the battlecard from library data and general positioning.
-> As you log deals, the battlecard will get richer with real evidence.
-
-**Competitor Not in Library:**
-> "[Name]" isn't in your library yet.
->
-> Options:
-> 1. Create the competitor entity first: `/octave:library create competitor "[name]"`
-> 2. I'll generate a basic comparison with available information
+- **No competitors in library**: Suggest adding one via `/octave:library create competitor` or offer to build a basic comparison from the provided name
+- **No deal data**: Build from library positioning and conversation data; note the battlecard will improve as deals are logged
+- **Competitor not in library**: Offer to create the entity via `/octave:library create competitor "[name]"` or generate a basic comparison with available information
 
 ## Related Skills
 
-- `/octave:research` - Research a specific account in a competitive deal
-- `/octave:campaign` - Generate competitive campaign content
-- `/octave:insights` - Surface competitive mentions from conversations
-- `/octave:wins-losses` - Analyze win/loss patterns against competitors
-- `/octave:enablement` - Package competitive intel for the team
+- `/octave:research` — Research a specific account in a competitive deal
+- `/octave:campaign` — Generate competitive campaign content
+- `/octave:insights` — Surface competitive mentions from conversations
+- `/octave:wins-losses` — Analyze win/loss patterns against competitors
+- `/octave:enablement` — Package competitive intel for the team

--- a/skills/battlecard/references/compare-template.md
+++ b/skills/battlecard/references/compare-template.md
@@ -1,0 +1,34 @@
+# Side-by-Side Compare Output Template
+
+```
+COMPARISON: [Your Product] vs [Competitor]
+==========================================
+
+| Category | [Your Product] | [Competitor] |
+|----------|---------------|-------------|
+| [Category 1] | [Our capability] | [Their capability] |
+| [Category 2] | [Our capability] | [Their capability] |
+| [Category 3] | [Our capability] | [Their capability] |
+| ... | ... | ... |
+
+DETAILED COMPARISON
+-------------------
+
+[Category 1]: [Category Name]
+Us: [Detailed description of our approach]
+Them: [Detailed description of their approach]
+Verdict: [Where each wins and why it matters]
+
+[Repeat for each major category]
+
+---
+
+SUMMARY
+-------
+Choose [Your Product] when: [Scenarios where you win]
+[Competitor] may be better when: [Be honest about their strengths]
+
+---
+
+Sources: [Competitor entity, product entity, proof points]
+```

--- a/skills/battlecard/references/displacement-template.md
+++ b/skills/battlecard/references/displacement-template.md
@@ -1,0 +1,77 @@
+# Displacement Campaign Output Template
+
+## Email Generation Call
+
+```
+generate_email({
+  person: { firstName: "[Persona Name]", jobTitle: "[Persona Title]" },
+  numEmails: 4,
+  sequenceType: "COLD_OUTBOUND",
+  allEmailsContext: "This person currently uses [Competitor]. Key competitor weaknesses: [list]. Our advantages: [list]. Proof of successful switches: [proof points]. Do NOT name the competitor unless the prospect mentions them first.",
+  allEmailsInstructions: "Displacement campaign. Progressive structure: Email 1: Pain-point their current tool likely causes. Email 2: Vision of what's possible (results from switchers). Email 3: Specific differentiation without naming competitor. Email 4: Direct offer with migration support."
+})
+```
+
+## Output Format
+
+```
+DISPLACEMENT CAMPAIGN: [Your Product] vs [Competitor]
+=====================================================
+
+Target: [Persona] currently using [Competitor]
+Strategy: [Lead with pain, prove with results, close with support]
+
+---
+
+POSITIONING STRATEGY
+--------------------
+Don't lead with: "[Competitor] is bad"
+Lead with: "[Pain they're likely experiencing because of competitor limitations]"
+
+Key angles:
+1. [Pain point caused by competitor weakness]
+2. [Results achieved by companies who switched]
+3. [Capability they're missing]
+
+---
+
+EMAIL 1: [Subject]
+Timing: Day 1 | Angle: Pain recognition
+---
+[Email body]
+
+EMAIL 2: [Subject]
+Timing: Day 4 | Angle: Social proof from switchers
+---
+[Email body]
+
+EMAIL 3: [Subject]
+Timing: Day 8 | Angle: Differentiation
+---
+[Email body]
+
+EMAIL 4: [Subject]
+Timing: Day 12 | Angle: Migration offer
+---
+[Email body]
+
+---
+
+LINKEDIN COMPANION MESSAGES
+----------------------------
+Connection note: [Short message]
+Follow-up: [After connection]
+
+---
+
+TALK TRACK (if they respond)
+-----------------------------
+Opening: "[How to start the conversation]"
+Discovery: "[Questions to understand their pain with current tool]"
+Transition: "[How to introduce your solution]"
+Close: "[Specific next step to offer]"
+
+---
+
+Sources: [Competitor entity, proof points, deal data]
+```

--- a/skills/battlecard/references/full-battlecard-template.md
+++ b/skills/battlecard/references/full-battlecard-template.md
@@ -1,0 +1,154 @@
+# Full Battlecard Output Template
+
+```
+BATTLECARD: [Your Product] vs [Competitor]
+==========================================
+
+Last Updated: [Date]
+Based on: [N] deal outcomes, [N] conversation mentions
+
+---
+
+QUICK POSITIONING
+-----------------
+When you hear: "[Competitor name]"
+Lead with: "[Key differentiator in one sentence]"
+
+30-Second Pitch:
+"[Elevator pitch that positions against this competitor]"
+
+---
+
+COMPETITOR OVERVIEW
+-------------------
+What they do: [Brief description from library]
+Target market: [Their focus]
+Pricing: [If known]
+Key customers: [Notable logos]
+Recent moves: [Latest news, features, funding]
+
+---
+
+WHERE WE WIN
+------------
+| Capability | Us | Them |
+|------------|-----|------|
+| [Area 1] | ✓ [Our strength] | ✗ [Their weakness] |
+| [Area 2] | ✓ [Our strength] | ~ [Partial/weaker] |
+| [Area 3] | ✓ [Our strength] | ✗ [Their gap] |
+
+Win Themes (from real deals):
+1. [Theme 1] — "[Evidence from conversation data]"
+2. [Theme 2] — "[Evidence from conversation data]"
+3. [Theme 3] — "[Evidence from conversation data]"
+
+---
+
+WHERE THEY WIN (BE HONEST)
+--------------------------
+| Capability | Them | Our Response |
+|------------|------|-------------|
+| [Area] | ✓ [Their strength] | [How we counter/reframe] |
+
+How to handle:
+• "[Their advantage]" → "[Reframe that shifts the conversation]"
+
+---
+
+COMMON OBJECTIONS
+-----------------
+
+"[Competitor] is cheaper"
+→ [Response: value, TCO, hidden costs, proof point]
+
+"[Competitor] has [feature X]"
+→ [Response: why it matters/doesn't, our alternative approach]
+
+"We already use [Competitor]"
+→ [Displacement angle: migration story, switching cost offset]
+
+"[Competitor] has more [integrations/customers/etc.]"
+→ [Response: quality vs quantity, specific advantage]
+
+Evidence: [Cite real objections from conversation data if available]
+
+---
+
+TRAP QUESTIONS
+--------------
+Ask these to expose their weaknesses:
+
+1. "[Question targeting known weakness]"
+   Why: [What this reveals]
+   If they say: "[Likely response]" → You say: "[Follow-up]"
+
+2. "[Question about scalability/support/depth]"
+   Why: [What this reveals]
+
+3. "[Question about specific capability gap]"
+   Why: [What this reveals]
+
+---
+
+LANDMINES TO SET
+----------------
+Plant these criteria early in the evaluation:
+
+1. "[Evaluation criterion]" — plays to our strength in [area]
+2. "[Technical requirement]" — exposes their limitation in [area]
+3. "[Process question]" — highlights our advantage in [area]
+
+---
+
+PROOF POINTS
+------------
+• [Customer who switched from competitor] — [Outcome]
+• [Metric: "X% better than [competitor] in Y"]
+• [Industry analyst or review quote]
+• [Head-to-head evaluation win]
+
+---
+
+DISPLACEMENT SUCCESS STORY
+---------------------------
+[Customer] switched from [Competitor] because:
+• [Reason 1]
+• [Reason 2]
+Results after switching:
+• [Metric improvement]
+• [Time saved / value gained]
+
+---
+
+DEAL WIN/LOSS PATTERNS
+-----------------------
+Wins against [Competitor]: [N] in last 180 days
+Losses to [Competitor]: [N] in last 180 days
+Win Rate: [X%]
+
+Common win factors:
+• [Factor 1]
+• [Factor 2]
+
+Common loss factors:
+• [Factor 1]
+• [Factor 2]
+
+---
+
+Sources Used:
+- Competitor entity: [name]
+- Deals analyzed: [N] wins, [N] losses
+- Conversation mentions: [N]
+- Proof points: [list]
+- Playbooks: [list]
+
+---
+
+Want me to:
+1. Deep dive on a specific objection
+2. Generate displacement outreach
+3. Create persona-specific version
+4. Add more trap questions
+5. Update the competitor entity with new insights
+```

--- a/skills/battlecard/references/landscape-template.md
+++ b/skills/battlecard/references/landscape-template.md
@@ -1,0 +1,30 @@
+# Competitive Landscape Output Template
+
+```
+COMPETITIVE LANDSCAPE
+=====================
+
+[Fetch all competitors and generate overview]
+
+MARKET MAP
+----------
+| Competitor | Focus | Threat Level | Our Win Rate |
+|-----------|-------|-------------|-------------|
+| [Comp 1] | [Focus] | [High/Med/Low] | [X%] |
+| [Comp 2] | [Focus] | [High/Med/Low] | [X%] |
+| [Comp 3] | [Focus] | [High/Med/Low] | [X%] |
+
+KEY THEMES
+----------
+• [Common competitive dynamic 1]
+• [Common competitive dynamic 2]
+• [Market trend affecting competition]
+
+PER-COMPETITOR SNAPSHOT
+-----------------------
+[Short battlecard summary for each competitor]
+
+---
+
+Want me to deep-dive on any competitor?
+```

--- a/skills/battlecard/references/objections-template.md
+++ b/skills/battlecard/references/objections-template.md
@@ -1,0 +1,64 @@
+# Objection Counters Output Template
+
+```
+OBJECTION COUNTERS: vs [Competitor]
+====================================
+
+PRICING OBJECTIONS
+------------------
+
+"[Competitor] is cheaper"
+→ [Response with TCO analysis, value framing]
+  Proof: "[Customer quote or metric]"
+
+"We don't have budget to switch"
+→ [Response about migration support, ROI timeline]
+  Proof: "[Switching ROI proof point]"
+
+---
+
+FEATURE OBJECTIONS
+------------------
+
+"[Competitor] has [Feature X]"
+→ [Response: our approach, why ours is better/different]
+  Proof: "[Evidence]"
+
+"[Competitor] integrates with [Tool Y]"
+→ [Response about our integrations or API]
+  Proof: "[Evidence]"
+
+---
+
+RELATIONSHIP OBJECTIONS
+-----------------------
+
+"We've been with [Competitor] for years"
+→ [Response: switching cost vs. opportunity cost]
+  Proof: "[Long-time customer who finally switched]"
+
+"Our team knows [Competitor]"
+→ [Response: onboarding experience, time to value]
+  Proof: "[Evidence]"
+
+---
+
+RISK OBJECTIONS
+---------------
+
+"Switching is too risky"
+→ [Response: migration support, phased approach]
+  Proof: "[Smooth migration story]"
+
+---
+
+FROM REAL CONVERSATIONS
+-----------------------
+[If conversation data available, cite actual objections heard and what worked]
+
+• "[Real objection from call]" — Handled by: [rep name/approach] — Outcome: [won/lost]
+
+---
+
+Sources: [Competitor entity, conversation findings, deal outcomes]
+```

--- a/skills/battlecard/references/traps-template.md
+++ b/skills/battlecard/references/traps-template.md
@@ -1,0 +1,44 @@
+# Trap Questions Output Template
+
+```
+TRAP QUESTIONS: vs [Competitor]
+================================
+
+Use these discovery questions to expose [Competitor]'s weaknesses
+without mentioning them directly.
+
+---
+
+QUESTION 1: [Area of weakness]
+"[Natural discovery question]"
+
+Why this works: [Competitor] struggles with [X], so their answer reveals gaps.
+If they say "[typical response]": Follow up with "[deeper question]"
+Our advantage: [What we do better here]
+
+---
+
+QUESTION 2: [Area of weakness]
+"[Natural discovery question]"
+
+Why this works: [Explanation]
+If they say "[typical response]": Follow up with "[deeper question]"
+Our advantage: [What we do better]
+
+---
+
+[Continue for 5-8 questions]
+
+---
+
+SEQUENCING ADVICE
+-----------------
+Ask in this order for maximum impact:
+1. [Question N] — establishes [criterion] as important
+2. [Question N] — builds on first, reveals gap
+3. [Question N] — introduces area where we dominate
+
+---
+
+Sources: [Competitor weaknesses, deal win patterns, conversation data]
+```

--- a/skills/campaign/SKILL.md
+++ b/skills/campaign/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: campaign
-description: Plan and generate multi-channel campaign content including email sequences, LinkedIn, ads, social, blog, and landing pages. Use when user says "create a campaign", "campaign for launch", "multi-channel outreach", "demand gen", or asks for coordinated content across channels. Do NOT use for single emails or messages — use /octave:generate instead.
+description: "Plan and generate multi-channel campaign content including email sequences, LinkedIn, ads, social, blog, and landing pages. Use when user says 'create a campaign', 'campaign for launch', 'multi-channel outreach', 'demand gen', or asks for coordinated content across channels. Do NOT use for single emails or messages — use /octave:generate instead."
 ---
 
 # /octave:campaign - Campaign Architect
@@ -20,7 +20,6 @@ Plan and generate integrated campaign content across channels — emails, Linked
 /octave:campaign "AI feature launch"                         # Campaign around a topic
 /octave:campaign "Q1 pipeline push" --persona "VP Engineering"
 /octave:campaign "competitive displacement" --playbook "Enterprise" --channels email,linkedin,ads
-/octave:campaign "customer expansion" --channels email,social
 ```
 
 ## Channel Options
@@ -42,431 +41,100 @@ When the user runs `/octave:campaign`:
 
 ### Step 1: Define Campaign Scope
 
-If no topic provided, ask:
+If no topic provided, ask the user to choose a campaign type:
 
-```
-What's the campaign about?
-
-GROWTH
-1. New product/feature launch
-2. Pipeline acceleration (drive meetings)
-3. Customer expansion / upsell
-4. Event promotion (webinar, conference)
-
-COMPETITIVE
-5. Competitive displacement
-6. Market positioning / thought leadership
-
-LIFECYCLE
-7. Re-engagement (cold leads, churned accounts)
-8. Nurture sequence (educate and warm)
-
-9. Something else - describe your campaign goal
-
-Your choice:
-```
+- **Growth**: New product/feature launch, pipeline acceleration, customer expansion/upsell, event promotion
+- **Competitive**: Competitive displacement, market positioning/thought leadership
+- **Lifecycle**: Re-engagement (cold leads, churned accounts), nurture sequence
+- **Custom**: User describes their own campaign goal
 
 ### Step 2: Gather Campaign Parameters
 
 Ask targeted questions based on campaign type:
 
-```
-Let's shape this campaign. A few questions:
-
-1. Target audience?
-   [List personas from library or "new/custom"]
-
-2. Which product/solution?
-   [List products from library]
-
-3. Key message or angle?
-   [Suggest based on playbook value props or "custom"]
-
-4. Which channels?
-   [email, linkedin, ads, social, blog, landing-page]
-   Default: email + linkedin
-
-5. Timeframe?
-   - Sprint (1-2 weeks)
-   - Standard (3-4 weeks)
-   - Extended (6-8 weeks)
-
-6. Any competitive context?
-   [List competitors or "none"]
-```
+1. **Target audience** — list personas from library or allow custom
+2. **Product/solution** — list products from library
+3. **Key message or angle** — suggest from playbook value props or allow custom
+4. **Channels** — select from channel options above (default: email + linkedin)
+5. **Timeframe** — Sprint (1-2 weeks), Standard (3-4 weeks), or Extended (6-8 weeks)
+6. **Competitive context** — list competitors from library or "none"
 
 ### Step 3: Gather Library Intelligence
 
-This is what makes the campaign intelligence-grounded, not just templated:
+Pull context from the Octave library to ground the campaign in real intelligence:
 
 ```
-# Get persona details
+# Core entities
 get_entity({ oId: "<persona_oId>" })
-
-# Get product details
 get_entity({ oId: "<product_oId>" })
 
-# Get matching playbook and value props
+# Playbook and value props
 search_knowledge_base({ query: "<campaign topic> <persona>", entityTypes: ["playbook"] })
 get_playbook({ oId: "<playbook_oId>", includeValueProps: true })
 
-# Get proof points for credibility
+# Proof points and competitive intel
 search_knowledge_base({ query: "<campaign topic>", entityTypes: ["proof_point", "reference"] })
+get_entity({ oId: "<competitor_oId>" })  // if competitive context exists
 
-# Get competitive positioning if relevant
-get_entity({ oId: "<competitor_oId>" })
-
-# Get brand voice
+# Brand consistency
 list_brand_voices()
-
-# Get writing style
 list_writing_styles()
 
-# Search for conversation insights on this topic
+# Topic insights
 search_knowledge_base({ query: "<campaign topic> objections pain points" })
 ```
 
 ### Step 4: Generate Campaign Strategy
 
-Present the campaign plan before generating content:
+Present the campaign plan before generating content, covering:
 
-```
-CAMPAIGN PLAN: [Campaign Name]
-==============================
+- **Objective** — one-sentence campaign goal
+- **Target Audience** — persona, segment, key pain points from library
+- **Strategic Angle** — playbook, lead value prop, supporting props
+- **Proof Points** — metrics, customer stories, references
+- **Competitive Positioning** — key differentiators (if applicable)
+- **Channel Plan** — table of channels with timing and purpose
 
-OBJECTIVE
----------
-[One-sentence goal]
-
-TARGET AUDIENCE
----------------
-Persona: [Persona name]
-Segment: [Segment if applicable]
-Key Pain Points:
-• [Pain point 1 from persona]
-• [Pain point 2 from persona]
-
-STRATEGIC ANGLE
----------------
-Playbook: [Playbook name]
-Lead Value Prop: [Primary value prop]
-Supporting Props:
-• [Value prop 2]
-• [Value prop 3]
-
-PROOF POINTS
-------------
-• [Proof point 1 — metric or customer story]
-• [Proof point 2]
-• [Reference customer if relevant]
-
-COMPETITIVE POSITIONING
------------------------
-[If competitive context exists]
-Key Differentiators:
-• [Differentiator 1]
-• [Differentiator 2]
-
-CHANNEL PLAN
-------------
-| Channel | Timing | Purpose |
-|---------|--------|---------|
-| [Channel 1] | [When] | [Role in campaign] |
-| [Channel 2] | [When] | [Role in campaign] |
-| ... | ... | ... |
-
----
-
-Ready to generate content for each channel? [Y/n]
-```
+Confirm with the user before proceeding to content generation.
 
 ### Step 5: Generate Channel Content
 
-Generate content for each selected channel:
+For each selected channel, use the appropriate MCP tool (`generate_email` for emails, `generate_content` for all others) with campaign context, persona pain points, value props, and proof points as input.
 
----
+See `references/CHANNEL-TEMPLATES.md` for detailed MCP tool calls and output formats for each channel.
 
-**Email Sequence:**
-```
-generate_email({
-  person: { firstName: "[Persona Name]", jobTitle: "[Persona Title]" },
-  numEmails: 4,
-  sequenceType: "COLD_OUTBOUND",  // or WARM_OUTBOUND based on campaign type
-  allEmailsContext: "<campaign angle, persona pain points, competitive positioning, proof points>",
-  allEmailsInstructions: "Campaign: [name]. Angle: [strategic angle]. Each email should build on the previous. Use proof points progressively."
-})
-```
+Key generation principles:
+- Each channel's content should reinforce the campaign's strategic angle
+- Use proof points progressively across the sequence (don't front-load everything)
+- Maintain brand voice consistency across all channels
+- Email sequences should build momentum — each email advances the narrative
+- Ad copy must respect character limits: Headline (30 chars), Body (90 chars), CTA (15 chars)
 
-Present as:
-```
-EMAIL SEQUENCE (4 emails)
-=========================
+### Step 6: Validate Generated Content
 
-EMAIL 1: [Subject Line]
-Timing: Day 1
-Purpose: [Hook with primary pain point]
----
-[Email body]
+After generating content for each channel, verify quality before presenting:
 
----
+1. **Brand voice check** — does the tone match `list_brand_voices()` output? Flag deviations.
+2. **Proof point accuracy** — are all cited metrics, quotes, and customer references drawn from the library? No fabricated stats.
+3. **Character limit compliance** — verify ad headlines (30 chars), ad body (90 chars), CTAs (15 chars), LinkedIn connection requests (300 chars).
+4. **Cross-channel consistency** — do all channels use the same core messaging, value props, and terminology?
+5. **Persona alignment** — does language match the persona's seniority level and domain vocabulary?
 
-EMAIL 2: [Subject Line]
-Timing: Day 3
-Purpose: [Social proof / value prop]
----
-[Email body]
+If any check fails, revise the affected content before presenting to the user.
 
----
+### Step 7: Present Campaign Summary
 
-EMAIL 3: [Subject Line]
-Timing: Day 6
-Purpose: [Differentiator / insight]
----
-[Email body]
+After generating and validating all channels, present a unified view:
 
----
-
-EMAIL 4: [Subject Line]
-Timing: Day 10
-Purpose: [Direct ask / breakup]
----
-[Email body]
-```
-
----
-
-**LinkedIn Messages:**
-```
-generate_content({
-  instructions: "Generate LinkedIn outreach for a campaign targeting [persona]. Create:
-    1. Connection request note (300 char max)
-    2. Follow-up message after connection (short, value-add)
-    3. LinkedIn post draft that the sales rep can publish (thought leadership angle)
-    All grounded in: [value props, pain points, proof points]",
-  customContext: "<library intelligence gathered>"
-})
-```
-
-Present as:
-```
-LINKEDIN CONTENT
-================
-
-CONNECTION REQUEST (300 chars)
-------------------------------
-[Message]
-
-FOLLOW-UP MESSAGE
------------------
-[Message after they accept]
-
-LINKEDIN POST (for rep to publish)
------------------------------------
-[Post draft — thought leadership angle related to campaign theme]
-
-ENGAGEMENT COMMENTS (templates)
--------------------------------
-If they post about [topic]: "[Comment]"
-If they share [content type]: "[Comment]"
-```
-
----
-
-**Ad Copy:**
-```
-generate_content({
-  instructions: "Generate 3 ad copy variants for a campaign targeting [persona].
-    Each variant needs: Headline (30 chars), Body (90 chars), CTA (15 chars).
-    Variant 1: Pain-point led. Variant 2: Social-proof led. Variant 3: Curiosity/insight-led.
-    All grounded in: [value props, differentiators, proof points]",
-  customContext: "<library intelligence>"
-})
-```
-
-Present as:
-```
-AD COPY VARIANTS
-================
-
-VARIANT 1: Pain-Led
-Headline: [30 chars]
-Body: [90 chars]
-CTA: [15 chars]
-
-VARIANT 2: Proof-Led
-Headline: [30 chars]
-Body: [90 chars]
-CTA: [15 chars]
-
-VARIANT 3: Insight-Led
-Headline: [30 chars]
-Body: [90 chars]
-CTA: [15 chars]
-```
-
----
-
-**Social Posts:**
-```
-generate_content({
-  instructions: "Generate 5 social media posts for a campaign targeting [persona].
-    Mix of: 1 stat/insight post, 1 question post, 1 mini case study, 1 hot take, 1 educational tip.
-    All connect back to: [campaign theme and value props].
-    Include hashtag suggestions.",
-  customContext: "<library intelligence>"
-})
-```
-
-Present as:
-```
-SOCIAL POSTS
-============
-
-POST 1: Stat/Insight
-[Post body]
-#hashtag1 #hashtag2
-
-POST 2: Question
-[Post body]
-
-POST 3: Mini Case Study
-[Post body]
-
-POST 4: Hot Take
-[Post body]
-
-POST 5: Educational Tip
-[Post body]
-```
-
----
-
-**Blog Post:**
-```
-generate_content({
-  instructions: "Generate a full blog post for a campaign targeting [persona].
-    Topic: [campaign theme]. Angle: [strategic angle].
-    Structure: Title, meta description, intro (hook), 3-4 main sections with subheadings,
-    conclusion with CTA. Weave in proof points naturally.
-    Length: 1200-1800 words. Tone: [brand voice].",
-  customContext: "<library intelligence, proof points, competitive positioning>"
-})
-```
-
-Present as:
-```
-BLOG POST
-=========
-
-Title: [Title]
-Meta Description: [155 chars]
-Target Persona: [Persona]
-
----
-
-[Full blog post content with sections]
-
----
-
-Internal CTA: [What to link to / landing page]
-```
-
----
-
-**Landing Page:**
-```
-generate_content({
-  instructions: "Generate landing page copy for a campaign targeting [persona].
-    Sections: Hero (headline, subheadline, CTA), Problem statement, Solution overview,
-    3 key benefits with descriptions, Social proof section (quotes, logos, metrics),
-    FAQ (3-4 questions), Final CTA.
-    Tone: [brand voice]. Focus: [campaign angle].",
-  customContext: "<library intelligence, proof points, differentiators>"
-})
-```
-
-Present as:
-```
-LANDING PAGE COPY
-=================
-
-HERO
-----
-Headline: [Headline]
-Subheadline: [Subheadline]
-CTA Button: [CTA text]
-
-PROBLEM
--------
-[Problem statement copy]
-
-SOLUTION
---------
-[Solution overview]
-
-KEY BENEFITS
-------------
-✓ [Benefit 1]: [Description]
-✓ [Benefit 2]: [Description]
-✓ [Benefit 3]: [Description]
-
-SOCIAL PROOF
-------------
-"[Customer quote]" — [Name, Title, Company]
-Metrics: [Key stats]
-Logos: [Suggest which reference customers]
-
-FAQ
----
-Q: [Question 1]
-A: [Answer]
-
-Q: [Question 2]
-A: [Answer]
-
-FINAL CTA
----------
-Headline: [Closing headline]
-CTA Button: [CTA text]
-Supporting: [Urgency/value text]
-```
-
-### Step 6: Present Campaign Summary
-
-After generating all channels, present a unified view:
-
-```
-CAMPAIGN SUMMARY: [Campaign Name]
-==================================
-
-Channels Generated:
-✓ Email sequence (4 emails)
-✓ LinkedIn (connection + follow-up + post)
-✓ Ad copy (3 variants)
-✓ Social posts (5 posts)
-✓ Blog post (1,500 words)
-✓ Landing page copy
-
-Library Sources Used:
-- Persona: [name]
-- Playbook: [name]
-- Value Props: [list]
-- Proof Points: [list]
-- Competitor: [name] (if applicable)
-- Brand Voice: [name]
-
----
-
-What would you like to do?
-
-1. Revise a specific channel's content
-2. Re-generate any piece using a saved agent
-3. Generate content for additional channels
-4. Adapt for a different persona
-5. Create a version for a different segment
-6. Export all content
-7. Done
-```
+- Checklist of channels generated with counts (e.g., "Email sequence — 4 emails")
+- Library sources used: persona, playbook, value props, proof points, competitor, brand voice
+- Next steps menu:
+  1. Revise a specific channel's content
+  2. Re-generate using a saved agent
+  3. Add more channels
+  4. Adapt for a different persona or segment
+  5. Export all content
+  6. Done
 
 ## Generation Mode Note
 
@@ -476,43 +144,23 @@ This skill uses Octave's `generate_content` and `generate_email` tools by defaul
 
 For the full interactive mode selector, use `/octave:generate`.
 
-## MCP Tools Used
-
-### Library Context
-- `list_all_entities` - List available personas, products, playbooks
-- `get_entity` - Get full entity details
-- `get_playbook` - Get playbook with value props
-- `list_value_props` - Get value propositions
-- `search_knowledge_base` - Find proof points, references, messaging
-- `list_brand_voices` - Get brand voice for consistency
-- `list_writing_styles` - Get writing style guidelines
-
-### Content Generation
-- `generate_email` - Email sequence generation
-- `generate_content` - All other content types (ads, social, blog, landing page, LinkedIn)
-
 ## Error Handling
 
-**No Personas Found:**
-> No personas in your library yet.
->
-> Campaigns work best when grounded in persona intelligence.
-> Run `/octave:library create persona` to add one, or I can generate generic campaign content.
+- **No personas found** — campaigns work best grounded in persona intelligence. Suggest `/octave:library create persona` or offer to generate generic content.
+- **No playbooks found** — fall back to product and persona information for messaging. Suggest `/octave:library create playbook` for better results.
+- **Single channel request** — generate the requested channel but suggest complementary channels at the end.
 
-**No Playbooks Found:**
-> No playbooks found matching this campaign topic.
->
-> I'll use your product and persona information to ground the messaging.
-> For better results, create a playbook: `/octave:library create playbook`
+## MCP Tools
 
-**Single Channel Request:**
-> If the user only wants one channel (e.g., "just emails"), generate that channel
-> but suggest complementary channels at the end.
+See `references/MCP-TOOLS.md` for the complete tool reference. Key tools:
+
+- **Library context**: `get_entity`, `get_playbook`, `search_knowledge_base`, `list_brand_voices`, `list_writing_styles`
+- **Generation**: `generate_email` (email sequences), `generate_content` (all other channels)
 
 ## Related Skills
 
-- `/octave:brainstorm campaigns` - Ideate campaign concepts before building
-- `/octave:generate` - Quick one-off content generation
-- `/octave:pmm` - Deep-dive collateral (case studies, one-pagers)
-- `/octave:repurpose` - Adapt campaign content for new audiences
-- `/octave:messaging` - Build messaging framework before campaign
+- `/octave:brainstorm campaigns` — ideate campaign concepts before building
+- `/octave:generate` — quick one-off content generation
+- `/octave:pmm` — deep-dive collateral (case studies, one-pagers)
+- `/octave:repurpose` — adapt campaign content for new audiences
+- `/octave:messaging` — build messaging framework before campaign

--- a/skills/campaign/references/CHANNEL-TEMPLATES.md
+++ b/skills/campaign/references/CHANNEL-TEMPLATES.md
@@ -1,0 +1,260 @@
+# Channel Content Templates
+
+Detailed output formats and MCP tool calls for each campaign channel. The main skill workflow references this file — use these templates when generating content for each channel.
+
+## Email Sequence
+
+**MCP Tool Call:**
+```
+generate_email({
+  person: { firstName: "[Persona Name]", jobTitle: "[Persona Title]" },
+  numEmails: 4,
+  sequenceType: "COLD_OUTBOUND",  // or WARM_OUTBOUND based on campaign type
+  allEmailsContext: "<campaign angle, persona pain points, competitive positioning, proof points>",
+  allEmailsInstructions: "Campaign: [name]. Angle: [strategic angle]. Each email should build on the previous. Use proof points progressively."
+})
+```
+
+**Output Format:**
+```
+EMAIL SEQUENCE (4 emails)
+=========================
+
+EMAIL 1: [Subject Line]
+Timing: Day 1
+Purpose: [Hook with primary pain point]
+---
+[Email body]
+
+---
+
+EMAIL 2: [Subject Line]
+Timing: Day 3
+Purpose: [Social proof / value prop]
+---
+[Email body]
+
+---
+
+EMAIL 3: [Subject Line]
+Timing: Day 6
+Purpose: [Differentiator / insight]
+---
+[Email body]
+
+---
+
+EMAIL 4: [Subject Line]
+Timing: Day 10
+Purpose: [Direct ask / breakup]
+---
+[Email body]
+```
+
+---
+
+## LinkedIn Messages
+
+**MCP Tool Call:**
+```
+generate_content({
+  instructions: "Generate LinkedIn outreach for a campaign targeting [persona]. Create:
+    1. Connection request note (300 char max)
+    2. Follow-up message after connection (short, value-add)
+    3. LinkedIn post draft that the sales rep can publish (thought leadership angle)
+    All grounded in: [value props, pain points, proof points]",
+  customContext: "<library intelligence gathered>"
+})
+```
+
+**Output Format:**
+```
+LINKEDIN CONTENT
+================
+
+CONNECTION REQUEST (300 chars)
+------------------------------
+[Message]
+
+FOLLOW-UP MESSAGE
+-----------------
+[Message after they accept]
+
+LINKEDIN POST (for rep to publish)
+-----------------------------------
+[Post draft — thought leadership angle related to campaign theme]
+
+ENGAGEMENT COMMENTS (templates)
+-------------------------------
+If they post about [topic]: "[Comment]"
+If they share [content type]: "[Comment]"
+```
+
+---
+
+## Ad Copy
+
+**MCP Tool Call:**
+```
+generate_content({
+  instructions: "Generate 3 ad copy variants for a campaign targeting [persona].
+    Each variant needs: Headline (30 chars), Body (90 chars), CTA (15 chars).
+    Variant 1: Pain-point led. Variant 2: Social-proof led. Variant 3: Curiosity/insight-led.
+    All grounded in: [value props, differentiators, proof points]",
+  customContext: "<library intelligence>"
+})
+```
+
+**Output Format:**
+```
+AD COPY VARIANTS
+================
+
+VARIANT 1: Pain-Led
+Headline: [30 chars]
+Body: [90 chars]
+CTA: [15 chars]
+
+VARIANT 2: Proof-Led
+Headline: [30 chars]
+Body: [90 chars]
+CTA: [15 chars]
+
+VARIANT 3: Insight-Led
+Headline: [30 chars]
+Body: [90 chars]
+CTA: [15 chars]
+```
+
+---
+
+## Social Posts
+
+**MCP Tool Call:**
+```
+generate_content({
+  instructions: "Generate 5 social media posts for a campaign targeting [persona].
+    Mix of: 1 stat/insight post, 1 question post, 1 mini case study, 1 hot take, 1 educational tip.
+    All connect back to: [campaign theme and value props].
+    Include hashtag suggestions.",
+  customContext: "<library intelligence>"
+})
+```
+
+**Output Format:**
+```
+SOCIAL POSTS
+============
+
+POST 1: Stat/Insight
+[Post body]
+#hashtag1 #hashtag2
+
+POST 2: Question
+[Post body]
+
+POST 3: Mini Case Study
+[Post body]
+
+POST 4: Hot Take
+[Post body]
+
+POST 5: Educational Tip
+[Post body]
+```
+
+---
+
+## Blog Post
+
+**MCP Tool Call:**
+```
+generate_content({
+  instructions: "Generate a full blog post for a campaign targeting [persona].
+    Topic: [campaign theme]. Angle: [strategic angle].
+    Structure: Title, meta description, intro (hook), 3-4 main sections with subheadings,
+    conclusion with CTA. Weave in proof points naturally.
+    Length: 1200-1800 words. Tone: [brand voice].",
+  customContext: "<library intelligence, proof points, competitive positioning>"
+})
+```
+
+**Output Format:**
+```
+BLOG POST
+=========
+
+Title: [Title]
+Meta Description: [155 chars]
+Target Persona: [Persona]
+
+---
+
+[Full blog post content with sections]
+
+---
+
+Internal CTA: [What to link to / landing page]
+```
+
+---
+
+## Landing Page
+
+**MCP Tool Call:**
+```
+generate_content({
+  instructions: "Generate landing page copy for a campaign targeting [persona].
+    Sections: Hero (headline, subheadline, CTA), Problem statement, Solution overview,
+    3 key benefits with descriptions, Social proof section (quotes, logos, metrics),
+    FAQ (3-4 questions), Final CTA.
+    Tone: [brand voice]. Focus: [campaign angle].",
+  customContext: "<library intelligence, proof points, differentiators>"
+})
+```
+
+**Output Format:**
+```
+LANDING PAGE COPY
+=================
+
+HERO
+----
+Headline: [Headline]
+Subheadline: [Subheadline]
+CTA Button: [CTA text]
+
+PROBLEM
+-------
+[Problem statement copy]
+
+SOLUTION
+--------
+[Solution overview]
+
+KEY BENEFITS
+------------
+✓ [Benefit 1]: [Description]
+✓ [Benefit 2]: [Description]
+✓ [Benefit 3]: [Description]
+
+SOCIAL PROOF
+------------
+"[Customer quote]" — [Name, Title, Company]
+Metrics: [Key stats]
+Logos: [Suggest which reference customers]
+
+FAQ
+---
+Q: [Question 1]
+A: [Answer]
+
+Q: [Question 2]
+A: [Answer]
+
+FINAL CTA
+---------
+Headline: [Closing headline]
+CTA Button: [CTA text]
+Supporting: [Urgency/value text]
+```

--- a/skills/campaign/references/MCP-TOOLS.md
+++ b/skills/campaign/references/MCP-TOOLS.md
@@ -1,0 +1,28 @@
+# MCP Tools Reference
+
+Tools used by the `/octave:campaign` skill, organized by function.
+
+## Library Context
+
+| Tool | Purpose |
+|------|---------|
+| `list_all_entities` | List available personas, products, playbooks |
+| `get_entity` | Get full entity details (persona, product, competitor) |
+| `get_playbook` | Get playbook with value props |
+| `list_value_props` | Get value propositions |
+| `search_knowledge_base` | Find proof points, references, messaging, objections |
+| `list_brand_voices` | Get brand voice for consistency |
+| `list_writing_styles` | Get writing style guidelines |
+
+## Content Generation
+
+| Tool | Purpose |
+|------|---------|
+| `generate_email` | Email sequence generation (supports `sequenceType`: COLD_OUTBOUND, WARM_OUTBOUND) |
+| `generate_content` | All other content types — ads, social, blog, landing page, LinkedIn |
+
+## Agent Discovery
+
+| Tool | Purpose |
+|------|---------|
+| `list_agents` | Check for saved agents that match the campaign context |

--- a/skills/deal-coach/SKILL.md
+++ b/skills/deal-coach/SKILL.md
@@ -17,16 +17,20 @@ An interactive coaching skill built around the **Resonate → Elevate → Compel
 **Three Coaching Outputs per Stage:**
 | Field | Type | Purpose |
 |-------|------|---------|
-| **Buyer Mindset** | String | Where the buyer's head is — psychology, fears, motivations |
+| **Buyer Mindset** | String | Buyer psychology — fears, motivations, awareness level |
 | **Value Propositions** | Array | Which value props to deploy and why they fit this stage |
 | **Talking Points** | Array | Specific things to say, grounded in deal context |
 
-This skill reads five coaching reference files at runtime:
-- `references/frameworks.md` — Resonate / Elevate / Compel: Buyer Mindset + Value Props + Talking Points
+This skill reads coaching reference files at runtime:
+- `references/frameworks.md` — Resonate / Elevate / Compel methodology
 - `references/coaching-agents.md` — 3 coaching agent personas + 2 cross-stage + scoring rubrics
 - `references/stage-mapping.md` — Buyer's Journey → coaching stage mapping + inference rules
 - `references/html-templates.md` — HTML section/slide templates per output mode
 - `references/messaging-narratives.md` — How coaching grounds in GTM context
+- `references/roleplay-templates.md` — Role play scenario setup, buyer behavior, scorecard templates
+- `references/microsite-templates.md` — Microsite outline, structural rules, content density limits
+- `references/deck-templates.md` — Slide outlines per stage, viewport/animation/navigation rules
+- `references/quiz-templates.md` — Quiz types, question bank structure, results template
 
 If reference files are not found, fall back to general coaching methodology and note the limitation.
 
@@ -75,22 +79,10 @@ AskUserQuestion({
     question: "What kind of deal coaching output do you want?",
     header: "Output Mode",
     options: [
-      {
-        label: "Role Play",
-        description: "Practice a coaching-backed conversation scored against Buyer Mindset, Value Props, and Talking Points. 8-12 exchanges, then a scorecard."
-      },
-      {
-        label: "Coaching Microsite",
-        description: "Self-contained HTML coaching page organized around Buyer Mindset / Value Propositions / Talking Points — with deal context, priority actions, and stage-grounded messaging."
-      },
-      {
-        label: "Coaching Deck",
-        description: "Slide presentation walking through the coaching framework for a specific deal, with stage-specific content and talk tracks."
-      },
-      {
-        label: "Interactive Quiz",
-        description: "Test coaching methodology knowledge with deal-grounded scenarios. Scoring breaks down by Resonate/Elevate/Compel."
-      }
+      { label: "Role Play", description: "Practice a coaching-backed conversation (8-12 exchanges + scorecard)" },
+      { label: "Coaching Microsite", description: "HTML coaching page with Buyer Mindset / Value Props / Talking Points" },
+      { label: "Coaching Deck", description: "Slide presentation walking through the coaching framework" },
+      { label: "Interactive Quiz", description: "Test methodology knowledge with deal-grounded scenarios" }
     ],
     multiSelect: false
   }]
@@ -115,14 +107,8 @@ AskUserQuestion({
     question: "Should this be grounded in a specific deal, or do you want generic practice?",
     header: "Deal Context",
     options: [
-      {
-        label: "Specific Deal",
-        description: "Ground coaching in a real account — uses CRM data, findings, events, and your playbook to make coaching deal-specific."
-      },
-      {
-        label: "Generic Practice",
-        description: "Practice the methodology with library-level data only (personas, playbook, proof points). No specific account context."
-      }
+      { label: "Specific Deal", description: "Ground coaching in a real account using CRM data, findings, and playbook" },
+      { label: "Generic Practice", description: "Practice with library-level data only (personas, playbook, proof points)" }
     ],
     multiSelect: false
   }]
@@ -131,27 +117,7 @@ AskUserQuestion({
 
 If **Generic Practice**: Skip to Step 2c.
 
-If **Specific Deal**: Ask for the company domain or contact email:
-
-```
-AskUserQuestion({
-  questions: [{
-    question: "What company domain or contact email should I research?",
-    header: "Company",
-    options: [
-      {
-        label: "Enter domain",
-        description: "e.g., acme.com"
-      },
-      {
-        label: "Enter email",
-        description: "e.g., jane@acme.com"
-      }
-    ],
-    multiSelect: false
-  }]
-})
-```
+If **Specific Deal**: Ask for domain or email, then proceed to 2b.
 
 #### 2b. Gather deal-specific context
 
@@ -180,20 +146,15 @@ list_all_entities({ entityType: "proofPoint" })
 get_playbook({ oId: "<matched_playbook_oId>" })
 ```
 
-If any tool call fails, note the gap and continue. Coach with available data and flag missing context.
+If any tool call fails, note the gap and continue with available data.
 
 #### 2c. Generic practice mode context
-
-For generic mode, gather library-level data only:
 
 ```
 search_knowledge_base({ query: "playbook" })
 list_all_entities({ entityType: "persona" })
 list_all_entities({ entityType: "competitor" })
 list_all_entities({ entityType: "proofPoint" })
-```
-
-```
 get_playbook({ oId: "<default_playbook_oId>" })
 ```
 
@@ -227,10 +188,10 @@ Use the weighted inference algorithm from `references/stage-mapping.md`:
 |--------|--------|--------|
 | CRM deal stage | 40% | `find_crm_records` → map to Resonate/Elevate/Compel |
 | Conversation findings | 30% | `list_findings` — pain points (→Resonate), competitor mentions (→Elevate), ROI/budget (→Compel) |
-| Deal activity patterns | 20% | `list_events` — discovery call (→Resonate), demo (→Elevate), proposal (→Compel) |
+| Deal activity patterns | 20% | `list_events` — discovery (→Resonate), demo (→Elevate), proposal (→Compel) |
 | Time in stage | 10% | Days in current stage vs. expectation |
 
-**For generic practice mode:** Skip inference. Let the user choose:
+**For generic practice mode:** Skip inference. Let the user choose a stage:
 
 ```
 AskUserQuestion({
@@ -238,18 +199,9 @@ AskUserQuestion({
     question: "Which coaching stage do you want to practice?",
     header: "Stage",
     options: [
-      {
-        label: "Resonate",
-        description: "Understand and resonate with the buyer — discovery principles, building trust through understanding"
-      },
-      {
-        label: "Elevate",
-        description: "Confirm the fit and elevate the opportunity — disrupt status quo, differentiate on value, build credibility"
-      },
-      {
-        label: "Compel",
-        description: "Deliver the value and compel the buyer to action — business case, Why Now, champion enablement"
-      }
+      { label: "Resonate", description: "Discovery principles, building trust through understanding" },
+      { label: "Elevate", description: "Disrupt status quo, differentiate on value, build credibility" },
+      { label: "Compel", description: "Business case, Why Now, champion enablement" }
     ],
     multiSelect: false
   }]
@@ -258,26 +210,9 @@ AskUserQuestion({
 
 #### 3b. Present inference and allow override
 
-**Confidence calibration:** CRM absence is a data hygiene issue, not a deal health signal. If CRM data is missing but activity signals are strong, redistribute the CRM weight across other signals.
+**Confidence calibration:** CRM absence is a data hygiene issue, not a deal health signal. If CRM data is missing but activity signals are strong, redistribute CRM weight across other signals.
 
-Present the inference:
-
-```
-STAGE INFERENCE
-===============
-Stage: [Resonate / Elevate / Compel]
-Confidence: [High / Medium / Low]
-Buyer's Journey Phase: [Phase Name]
-
-EVIDENCE
---------
-CRM Stage (40%): "[Stage Name]" → maps to [Stage]  [or "No CRM record — data gap, not deal gap"]
-Findings (30%): [Key signals]
-Activities (20%): [Key activities]
-Time (10%): [Assessment]
-```
-
-Then confirm:
+Present the inference summary (stage, confidence, buyer's journey phase, evidence breakdown), then confirm:
 
 ```
 AskUserQuestion({
@@ -285,44 +220,20 @@ AskUserQuestion({
     question: "Does this stage assessment look right?",
     header: "Confirm Stage",
     options: [
-      {
-        label: "Yes — proceed with [Stage]",
-        description: "Generate [selected mode] coaching for [Stage]"
-      },
-      {
-        label: "No — let me pick",
-        description: "Override the inference and choose a different stage"
-      },
-      {
-        label: "Show all stages",
-        description: "See all 3 stages with descriptions before choosing"
-      }
+      { label: "Yes — proceed with [Stage]", description: "Generate [mode] coaching for [Stage]" },
+      { label: "No — let me pick", description: "Override and choose a different stage" },
+      { label: "Show all stages", description: "See all 3 stages before choosing" }
     ],
     multiSelect: false
   }]
 })
 ```
 
-If user picks "No" or "Show all stages," present the full stage list (same as generic mode above).
+If user overrides, present the full stage list (same as generic mode).
 
 #### 3c. Stall detection
 
-If time-in-stage signals indicate a stalled deal (>2x expected time), add stall diagnosis:
-
-```
-STALL DETECTION
-===============
-This deal appears stalled at [Journey Phase].
-Time in stage: [X] days (expected: [Y] days)
-
-Root Cause Hypothesis: [Stage] gap
-- [Explanation of why this stage gap is likely the root cause]
-- [Specific evidence from findings/activities]
-
-Recommendation: Focus coaching on [Root Cause Stage], not the nominal CRM stage.
-```
-
-Route to the root cause stage's coaching agent, not the nominal stage.
+If time-in-stage indicates a stalled deal (>2x expected time), add stall diagnosis: identify the root cause stage gap, explain why, cite evidence, and recommend focusing coaching on that stage instead of the nominal CRM stage.
 
 ---
 
@@ -340,700 +251,65 @@ Based on the confirmed stage, activate the appropriate coaching agent from `refe
 - **Negotiation Strategist** — Available when stage is Compel and negotiation dynamics surface
 - **Objection Handler** — Available at any stage when objections surface in findings
 
-Load the agent's persona, coaching criteria, scoring rubric, and grounding instructions from the reference file. Use the grounding map from `references/messaging-narratives.md` to connect the agent's outputs to the seller's Octave library data.
+Load the agent's persona, coaching criteria, scoring rubric, and grounding instructions from the reference file. Use the grounding map from `references/messaging-narratives.md` to connect outputs to Octave library data.
 
 ---
 
 ### Step 5: Generate Output (CT-5)
 
-Branch based on the output mode selected in Step 1.
+Branch based on the output mode selected in Step 1. Each mode has detailed templates in its reference file.
 
 ---
 
-#### Mode 1: Role Play (RP-1 through RP-4)
+#### Mode 1: Role Play
 
-##### RP-1: Setup the Scenario
+Follow the full workflow in `references/roleplay-templates.md` (RP-1 through RP-4):
 
-```
-AskUserQuestion({
-  questions: [{
-    question: "What kind of role play do you want?",
-    header: "Scenario",
-    options: [
-      {
-        label: "Single Stage Practice",
-        description: "Practice one stage ([Stage]) in a focused 8-12 exchange conversation"
-      },
-      {
-        label: "Full Journey Simulation",
-        description: "Walk through Resonate → Elevate → Compel in sequence, simulating the full buying journey"
-      }
-    ],
-    multiSelect: false
-  },
-  {
-    question: "How difficult should the buyer be?",
-    header: "Difficulty",
-    options: [
-      {
-        label: "Friendly",
-        description: "Buyer is open and receptive. Good for learning the coaching framework."
-      },
-      {
-        label: "Skeptical",
-        description: "Buyer pushes back moderately. Tests methodology under pressure."
-      },
-      {
-        label: "Hostile",
-        description: "Buyer is resistant, dismissive, or aggressive. Tests advanced skills and composure."
-      }
-    ],
-    multiSelect: false
-  }]
-})
-```
+1. **RP-1 — Setup:** Ask for scenario type (single stage vs. full journey), difficulty, and buyer persona
+2. **RP-2 — Load Intelligence:** Load coaching rubric, grounding map, and stage-specific buyer behavior rules
+3. **RP-3 — Run Role Play:** Set the scene, play the buyer persona with stage-appropriate behavior and difficulty-adjusted resistance. 8-12 exchanges for single stage; sequential stages for full journey.
+4. **RP-4 — Scorecard:** Score across Buyer Mindset, Value Propositions, Talking Points (stage-specific criteria), and General Selling Skills. Include key moments, coaching advice, and unused value props.
 
-If in specific-deal mode, identify the buyer persona from entities gathered in Step 2. If generic, let the user choose from available personas:
-
-```
-AskUserQuestion({
-  questions: [{
-    question: "Which persona should the buyer represent?",
-    header: "Buyer Persona",
-    options: [
-      // Dynamically populated from list_all_entities({ entityType: "persona" })
-      {
-        label: "[Persona Name]",
-        description: "[Persona title/role — from entity data]"
-      }
-      // ... up to 4 personas
-    ],
-    multiSelect: false
-  }]
-})
-```
-
-##### RP-2: Load Stage-Specific Intelligence
-
-Load the coaching agent's rubric and grounding map for the selected stage.
-
-For deal-specific mode, map all Octave data to coaching output fields using `references/messaging-narratives.md`.
-
-For generic mode, use playbook-level data to create a representative scenario.
-
-Prepare buyer behavior rules based on stage:
-
-| Stage | Buyer Psychology | Behavior Rules |
-|-------|-----------------|---------------|
-| Resonate | Exploratory, guarded | Shares surface problems, tests whether seller digs deeper. Friendly: volunteers info. Hostile: one-word answers. |
-| Elevate | Status quo defender / comparison shopper | Resists change, references competitors. Friendly: open to new perspective. Hostile: "We've been doing fine for years" / "Your competitor does that too." |
-| Compel | Analytical, needs numbers, risk-averse | Asks about ROI, pushes back on vague claims. Friendly: engages with data. Hostile: "Those numbers don't apply to us" / "Now is not the right time." |
-
-##### RP-3: Run the Role Play
-
-Set the scene:
-
-```
-=======================================
-DEAL COACHING ROLE PLAY: [Stage]
-=======================================
-
-THE SCENE
----------
-You are a seller from [company/product] meeting with [Persona Name], [Title] at [Company].
-[If deal-specific: Brief deal context from CRM]
-[If generic: Practice scenario description]
-
-COACHING STAGE: [Resonate / Elevate / Compel]
-[Stage subLabel — e.g., "Understand and resonate with the buyer"]
-
-Your goal is to demonstrate strong execution across:
-- Buyer Mindset — accurately read and adapt to the buyer
-- Value Propositions — deploy the right props for this stage
-- Talking Points — execute the stage's methodology naturally
-
-BUYER PROFILE
-- Name: [Persona Name]
-- Role: [Title]
-- Mindset: [Stage-appropriate psychology]
-- Difficulty: [Friendly/Skeptical/Hostile]
-
-RULES
------
-1. This is a CONVERSATION — respond naturally as the seller
-2. I will play [Persona Name] with [difficulty]-level resistance
-3. The conversation will run 8-12 exchanges
-4. You'll be scored on Buyer Mindset, Value Props, and Talking Points
-5. I'll signal when the conversation is wrapping up
-6. Stay in character — no breaking the fourth wall
-
-Ready? I'll start as [Persona Name]...
-=======================================
-```
-
-Then begin as the buyer persona:
-- Play the buyer with stage-appropriate behavior (see table above)
-- Adjust resistance based on difficulty level
-- Drop stage-relevant cues that a well-trained seller should pick up on
-- **Friendly:** give verbal rewards when the seller executes methodology correctly
-- **Skeptical:** push back on weak points but yield to strong methodology
-- **Hostile:** resist aggressively; only yield to excellent execution
-- Allow natural conversation flow — don't force every principle or beat
-- After 8-12 exchanges, signal wrap-up: "I think we're running short on time..."
-
-For **Full Journey Simulation**:
-- Start at Resonate and progress through each stage
-- After each stage, pause: "Good — let's fast-forward. [Context for next stage]."
-- Score each stage independently, then provide a cumulative scorecard
-
-##### RP-4: Coaching Scorecard
-
-After the role play ends:
-
-```
-DEAL COACHING SCORECARD
-=======================
-Stage: [Resonate / Elevate / Compel]
-Coaching Agent: [Agent Name]
-Difficulty: [Friendly/Skeptical/Hostile]
-Persona: [Buyer Name], [Title]
-
-BUYER MINDSET
--------------
-| Criterion | Score | Notes |
-|-----------|-------|-------|
-| Awareness read | [1-5] | [Did they correctly assess where the buyer is?] |
-| Adaptation | [1-5] | [Did they adjust their approach based on buyer signals?] |
-| Psychology match | [1-5] | [Did they match the buyer's emotional state before trying to move it?] |
-
-Buyer Mindset Score: [avg]/5
-
-VALUE PROPOSITIONS
-------------------
-| Criterion | Score | Notes |
-|-----------|-------|-------|
-| Stage appropriateness | [1-5] | [Did they use props fitting for this stage?] |
-| Selection quality | [1-5] | [Did they pick the most impactful props available?] |
-| Deployment timing | [1-5] | [Did they introduce props at the right moment?] |
-
-Value Propositions Score: [avg]/5
-
-TALKING POINTS
---------------
-[Scoring varies by stage — use the stage-specific criteria from coaching-agents.md]
-
-[Resonate:]
-| Criterion | Score | Notes |
-|-----------|-------|-------|
-| Going wide | [1-5] | [Did they map the landscape — stakeholders, history, context?] |
-| Going deep | [1-5] | [Did they find root causes, not just symptoms?] |
-| Going high | [1-5] | [Did they connect to business and personal impact?] |
-| Problem statement quality | [1-5] | [Did they arrive at a crisp, multi-dimensional problem?] |
-
-[Elevate:]
-| Criterion | Score | Notes |
-|-----------|-------|-------|
-| Case for Change delivery | [1-5] | [Did they hit the three beats — Shift, Stakes, Possibility?] |
-| Value Framing | [1-5] | [Did they translate to Buyer/Executive voice, not just Product voice?] |
-| Differentiation quality | [1-5] | [Did they focus on differentiated value?] |
-| Proof point usage | [1-5] | [Did they use specific, credible proof?] |
-
-[Compel:]
-| Criterion | Score | Notes |
-|-----------|-------|-------|
-| Business case quality | [1-5] | [Did they co-create quantified value?] |
-| Value chain clarity | [1-5] | [Did they map capability → outcome → dollars?] |
-| Why Now execution | [1-5] | [Both dimensions — business and personal urgency?] |
-| Champion enablement | [1-5] | [Did they arm the champion?] |
-
-Talking Points Score: [avg]/5
-
-GENERAL SELLING SKILLS
-----------------------
-| Element | Score | Notes |
-|---------|-------|-------|
-| Opening / rapport | [1-5] | [Assessment] |
-| Active listening | [1-5] | [Assessment] |
-| Proof point usage | [1-5] | [Assessment] |
-| Call control | [1-5] | [Assessment] |
-| Natural delivery | [1-5] | [Assessment] |
-
-OVERALL SCORE: [X]/5
-Buyer Mindset: [avg]/5 | Value Props: [avg]/5 | Talking Points: [avg]/5 | General: [avg]/5
-
-KEY MOMENTS
------------
-[Quote from conversation + assessment — what was done well or could improve]
-[Repeat for 3-5 key moments]
-
-COACH SAYS
-----------
-[2-3 paragraphs of specific coaching advice from the stage's coaching agent persona.
-Reference specific Talking Points from frameworks.md.
-Ground in the seller's playbook messaging.
-Identify #1 area for improvement and give a concrete example of what to say instead.]
-
-VALUE PROPS YOU COULD HAVE USED
--------------------------------
-[List 3-5 value props from the library that would have strengthened the conversation, with:
-- The prop itself
-- When to deploy it (which moment in the conversation)
-- How to frame it for this stage (Buyer/Executive voice, not feature pitch)]
-```
-
-After the scorecard:
-
-```
-Want to:
-1. Run this role play again (same stage, same difficulty)
-2. Try a harder difficulty level
-3. Practice the next stage ([Next Stage])
-4. Practice objection handling for this stage
-5. Get a coaching microsite for this stage
-6. Switch to a different output mode
-7. Done
-```
+Post-scorecard: offer replay, harder difficulty, next stage, objection handling, microsite, mode switch, or done.
 
 ---
 
-#### Mode 2: Coaching Microsite (MS-1 through MS-3)
+#### Mode 2: Coaching Microsite
 
-##### MS-1: Style Selection
+Follow the full workflow in `references/microsite-templates.md` (MS-1 through MS-3):
 
-Reference the style preset system from `skills/deck/references/STYLE_PRESETS.md`.
-
-Each coaching stage has a default style preset:
-
-| Stage | Default Preset | Rationale |
-|-------|---------------|-----------|
-| Resonate | `soft-light` | Exploratory, calm, trust-building |
-| Elevate | `midnight-pro` | Urgency, disruption, bold contrast |
-| Compel | `executive-dark` | Business gravitas, financial seriousness |
-
-Present the default with option to override:
-
-```
-AskUserQuestion({
-  questions: [{
-    question: "The default style for [Stage] is [preset name] ([rationale]). Want to use it or pick a different style?",
-    header: "Style",
-    options: [
-      {
-        label: "[Default Preset] (Recommended)",
-        description: "[Preset description]"
-      },
-      {
-        label: "Pick a different style",
-        description: "Choose from available presets"
-      },
-      {
-        label: "Auto-pick from brand",
-        description: "Extract colors from the company's website and generate a custom theme"
-      }
-    ],
-    multiSelect: false
-  }]
-})
-```
-
-If user picks "Pick a different style," present mood-based preview options (follow the pattern from `deck/SKILL.md` Step 4).
-
-##### MS-2: Generate Content Outline
-
-Before generating HTML, present the content plan:
-
-```
-COACHING MICROSITE OUTLINE
-==========================
-Company: [Company Name]
-Stage: [Resonate / Elevate / Compel] — [Stage subLabel]
-Coaching Agent: [Agent Name]
-Style: [Preset Name]
-
-STRUCTURE
----------
-Header + Deal Brief    — Company name, industry, date, coaching stage badge,
-                         deal-specific subtitle, deal stats grid
-Priority Actions       — 3 quick-hit actions before the next meeting (collapsible)
-Deal Activity          — Compact vertical timeline of deal events with dates (collapsible)
-Journey Map            — 3-phase coaching journey (Resonate → Elevate → Compel) showing
-                         where the deal is and why, with generic phase explanations AND
-                         deal-specific context for each phase (collapsible)
-Section 01: Stage Assessment     — How stage was inferred, evidence, confidence
-Section 02: Buyer Mindset        — Buyer psychology assessment, awareness level, trigger,
-                                   constraints, adaptation guidance
-Section 03: Value Propositions   — Stage-appropriate props from library with deployment
-                                   guidance, evidence inline, usage notes (deploy now vs.
-                                   save for later stage vs. already shared)
-Section 04: Talking Points       — Stage-specific talk tracks organized by conversation
-                                   flow, with strategic point + sample quote + evidence.
-                                   Do NOT use framework labels as headers (e.g., "The Shift").
-                                   Use practical, deal-specific language.
-Section 05: Objection Handling   — Likely objections grounded in buyer's actual decision
-                                   frame, with stage-appropriate responses
-Section 06: Next Stage Preview   — Transition checklist + next coaching agent preview
-[Optional] Section 07: Deal Gaps (MEDDPICC) — Coverage assessment with gap-to-action mapping
-The Play               — Strategic one-liner + concrete "your next move is X" action
-
-DESIGN PRINCIPLES
------------------
-- The three coaching outputs (Buyer Mindset, Value Props, Talking Points) are the
-  organizing principle
-- Evidence (proof points, metrics) is folded INTO the relevant sections inline,
-  not in a standalone section
-- Objections go in Section 05, grounded in the buyer's actual decision frame
-  (build vs. buy, do-nothing vs. act, this vendor vs. that)
-- MEDDPICC is available as an optional section — not the primary structure
-- Talk tracks use a two-layer structure: strategic point (bold, practical deal
-  language — NOT framework labels) then sample quote (italic, one way to express it).
-  Each includes "Use when..." guidance for timing.
-- No duplicate content between sections. Each piece of information appears once.
-- Use "perspective-shifting question" framing — tone is collaborative and consultative
-- This is a selling tool. Orient language around advancing the deal.
-
-OCTAVE SOURCES
---------------
-- Playbook: [Playbook Name]
-- Personas: [N] loaded
-- Proof Points: [N] loaded
-- Findings: [N] loaded
-- Competitors: [N] loaded
-- CRM: [Stage, Amount, Close Date or "Generic mode — no CRM data"]
-
-Generate this microsite?
-1. Yes — generate
-2. Adjust sections
-3. Change style
-4. Start over
-```
-
-##### MS-3: Generate HTML
-
-Use templates from `references/html-templates.md` to generate a self-contained HTML file.
-
-**Content grounding rules** (from `references/messaging-narratives.md`):
-- Every Value Proposition must reference specific playbook messaging — never generic claims
-- Every proof point must cite a specific library entity, appear inline in the section it supports, and include a usage note (deploy now / save for later / already shared)
-- Every Talking Point must be grounded in the deal context (if available) and connected to the Buyer Mindset
-- Every objection response must be grounded in the specific decision the buyer is making — not generic competitive objections
-- Use "perspective-shifting question" framing — collaborative, not adversarial
-- This is a selling tool — orient language around advancing the deal
-
-**Structural rules:**
-- Header + Deal Brief is NOT collapsible — full-width gradient hero with deal stats
-- Priority Actions, Deal Activity, and Journey Map are collapsible `<details>` with +/− toggle
-- Sections 01-06 (07 if MEDDPICC included) are collapsible `<details>` elements
-- ALL collapsible sections start COLLAPSED by default (no `open` attribute)
-- The Play is NOT collapsible — full-width gradient footer
-- No duplicate content between sections
-- Evidence goes inline (not standalone)
-- Do NOT use framework labels as visible headers in Talking Points (e.g., "The Shift", "The Stakes"). Use practical deal-specific language. The framework informs content structure internally.
-- Do NOT include both "Elevate" and "Evaluate" badges in the header — use "Coaching Stage: [Name]" only. The Journey Map section explains the buyer journey mapping.
-
-**Content density limits:**
-| Section | Limit |
-|---------|-------|
-| Header + Deal Brief | Company info + 4-6 deal stats + coaching stage badge + deal-specific subtitle |
-| Priority Actions | Exactly 3 actions |
-| Deal Activity | 3-6 timeline entries (key events + "Next" entry) |
-| Journey Map | 3 phases (Resonate/Elevate/Compel), each with generic explanation + deal-specific context |
-| Stage Assessment | 3-4 evidence cards + confidence calibration |
-| Buyer Mindset | Mindset narrative + 3-5 buyer signals + adaptation guidance |
-| Value Propositions | 4-6 props with evidence inline and usage notes |
-| Talking Points | 4-6 talk tracks (strategic point + quote + evidence) organized by conversation flow |
-| Objection Handling | 3-5 objections grounded in buyer's decision frame |
-| Next Stage Preview | 1 transition checklist + next agent preview |
-| Deal Gaps (MEDDPICC) | 8 elements + gap-to-action mapping (if included) |
-| The Play | 1 strategic sentence + 1 concrete action |
-
-**Output location:**
-```
-.octave-deal-coach/
-  [company-kebab]-[stage]-[YYYY-MM-DD]/
-    [company-kebab]-[stage].html
-
-Example:
-.octave-deal-coach/acme-corp-elevate-2026-03-03/acme-corp-elevate.html
-```
-
-For generic mode, use `practice` instead of company name:
-```
-.octave-deal-coach/practice-resonate-2026-03-03/practice-resonate.html
-```
-
-After writing the file, open it:
-```bash
-open "[file path]"
-```
+1. **MS-1 — Style:** Select style preset (stage defaults: Resonate→soft-light, Elevate→midnight-pro, Compel→executive-dark) with override option
+2. **MS-2 — Outline:** Present content plan (header, priority actions, deal activity, journey map, 6-7 coaching sections, the play) for approval
+3. **MS-3 — Generate HTML:** Build self-contained HTML using `references/html-templates.md`, following structural rules and content density limits from the microsite templates reference
 
 ---
 
-#### Mode 3: Coaching Deck (DK-1 through DK-3)
+#### Mode 3: Coaching Deck
 
-##### DK-1: Style Selection
+Follow the full workflow in `references/deck-templates.md` (DK-1 through DK-3):
 
-Same as MS-1. Use stage-appropriate default presets.
-
-##### DK-2: Generate Slide Outline
-
-Present the slide outline for approval. Slide content varies by stage:
-
-**Resonate (~7 slides):**
-1. Title Slide — "[Company] — Resonate" + stage badge
-2. Stage Context — Deal position, buyer's journey phase, buyer mindset assessment
-3. Buyer Mindset Deep Dive — Awareness level, trigger, constraints, adaptation guidance
-4. Discovery Principles — Go wide, go deep, go high — applied to this deal
-5. Value Propositions — Stage-appropriate props with deployment guidance
-6. Talking Points — Discovery questions and conversation starters with listening cues
-7. Next Steps — Transition checklist to Elevate
-
-**Elevate (~9 slides):**
-1. Title Slide — "[Company] — Elevate" + stage badge
-2. Stage Context — Deal position, competitive landscape, buyer mindset
-3. Buyer Mindset Deep Dive — Status quo attachment, change readiness, evaluation mode
-4. The Case for Change — The Shift → The Stakes → The Possibility for this deal
-5. Differentiated Value — What's unique AND important to this buyer
-6. Value Propositions — Value Framing examples (Product → Buyer → Executive voice)
-7. Talking Points — Case for Change talk tracks + differentiation delivery
-8. Proof Points — Evidence grid with deployment guidance
-9. Next Steps — Transition checklist to Compel
-
-**Compel (~9 slides):**
-1. Title Slide — "[Company] — Compel" + stage badge
-2. Stage Context — Decision dynamics, stakeholder positions, buyer mindset
-3. Buyer Mindset Deep Dive — Decision process, champion strength, detractors, risk appetite
-4. Before vs. After — Side-by-side with quantified delta
-5. Value Chain — Capability → workflow improvement → business outcome → financial result
-6. Value Propositions — ROI-focused props with quantified outcomes per stakeholder
-7. The Why Now Case — Business urgency + personal urgency
-8. Talking Points — Business case narration + champion enablement scripts
-9. Next Steps — Decision pathway and timeline
-
-Present outline and ask:
-
-```
-Generate this deck?
-1. Yes — generate
-2. Adjust slides
-3. Change style
-4. Start over
-```
-
-##### DK-3: Generate HTML Deck
-
-Use slide templates from `references/html-templates.md` for a self-contained HTML file with scroll-snap slide architecture.
-
-**Viewport fitting rules** (from `deck/SKILL.md`):
-- ALL font sizes use `clamp()` — never fixed px
-- ALL spacing uses `clamp()`
-- Strict content per slide: Title = 1 heading + 1 subtitle; Content = 1 heading + 4-6 bullets; Grid = max 6 cards
-- If content exceeds limits, split into additional slides
-- `overflow: hidden` on every `.slide`
-- Media queries at 700px, 600px, 500px for short viewports
-
-**Animation:**
-- Staggered entrance via Intersection Observer
-- `.animate-in` class with opacity + translateY
-- `nth-child` stagger delays
-- Respect `prefers-reduced-motion`
-
-**Navigation:**
-- Keyboard: ArrowDown/Up, Space, PageDown/Up
-- Scroll snap for touch/trackpad
-- Progress bar + nav dots
-- Print: `page-break-after: always`, remove snap
-
-**Output location:**
-```
-.octave-deal-coach/
-  [company-kebab]-deck-[stage]-[YYYY-MM-DD]/
-    [company-kebab]-deck-[stage].html
-```
-
-After writing, open in browser:
-```bash
-open "[file path]"
-```
+1. **DK-1 — Style:** Same as microsite style selection
+2. **DK-2 — Outline:** Present stage-specific slide outline (Resonate ~7, Elevate ~9, Compel ~9 slides) for approval
+3. **DK-3 — Generate HTML:** Build scroll-snap HTML deck using `references/html-templates.md`, following viewport fitting, animation, and navigation rules from the deck templates reference
 
 ---
 
-#### Mode 4: Interactive Quiz (QZ-1 through QZ-4)
+#### Mode 4: Interactive Quiz
 
-##### QZ-1: Choose Quiz Type
+Follow the full workflow in `references/quiz-templates.md` (QZ-1 through QZ-4):
 
-```
-AskUserQuestion({
-  questions: [{
-    question: "What type of coaching quiz do you want?",
-    header: "Quiz Type",
-    options: [
-      {
-        label: "Stage Recognition",
-        description: "A buyer says X — which coaching stage? Tests your ability to diagnose where a deal is."
-      },
-      {
-        label: "Methodology Application",
-        description: "You're in [Stage] — what's the right Buyer Mindset, Value Props, and Talking Points approach? Tests methodology knowledge."
-      },
-      {
-        label: "Talk Track Completion",
-        description: "Buyer says [objection/question]. Using the coaching methodology, what's your response?"
-      },
-      {
-        label: "Full Review",
-        description: "Mix of all categories covering Resonate, Elevate, and Compel. Comprehensive assessment."
-      }
-    ],
-    multiSelect: false
-  },
-  {
-    question: "How many questions?",
-    header: "Length",
-    options: [
-      {
-        label: "Quick (5 questions)",
-        description: "Fast check — 5-10 minutes"
-      },
-      {
-        label: "Standard (10 questions)",
-        description: "Thorough assessment — 15-20 minutes"
-      },
-      {
-        label: "Deep (15 questions)",
-        description: "Comprehensive review — 25-30 minutes"
-      }
-    ],
-    multiSelect: false
-  }]
-})
-```
+1. **QZ-1 — Setup:** Choose quiz type (stage recognition, methodology application, talk track completion, full review) and length (5/10/15 questions)
+2. **QZ-2 — Load Material:** Build question bank by category, grounded in deal or playbook data
+3. **QZ-3 — Run Quiz:** Present questions one at a time with immediate feedback and running score
+4. **QZ-4 — Results:** Score breakdown by stage, coaching dimension, and category. Identify strengths, gaps, and recommended next steps.
 
-##### QZ-2: Load Quiz Material
-
-Load coaching content from reference files. If deal-specific, ground questions in actual deal data. If generic, use playbook-level data.
-
-Build question bank by category:
-
-**Stage Recognition:**
-- Present a buyer quote or scenario → ask which stage
-- Use findings and CRM data for realistic scenarios
-- Include red herrings (scenarios that seem like one stage but are actually another)
-
-**Methodology Application:**
-- Name a stage → ask for the right approach
-- E.g., "You're in Elevate. What are the three beats of the Case for Change?"
-- E.g., "A buyer says they're evaluating competitors. Which coaching output fields should you focus on, and what goes in each?"
-- Include application questions that test Buyer Mindset → Value Props → Talking Points mapping
-
-**Talk Track Completion:**
-- Present a buyer statement → ask for the methodology-backed response
-- E.g., "Buyer: 'We're happy with what we have.' Using the Elevate methodology, what do you say next?"
-- Score on methodology adherence AND natural delivery
-
-**Full Review:**
-- Mix all categories
-- Weight toward the selected/inferred stage
-- Ensure coverage across all three stages
-
-##### QZ-3: Run the Quiz
-
-Present questions one at a time:
-
-```
-QUESTION [N]/[Total]
-Category: [Stage Recognition / Methodology Application / Talk Track Completion]
-Stage: [Resonate / Elevate / Compel]
-[If deal-grounded: "Based on your [Company] deal"]
-
-[Question text]
-
-[For multiple choice: Present 4 options]
-[For open-ended: Ask the user to type their response]
-```
-
-After each answer:
-
-```
-[Correct / Partially Correct / Incorrect]
-
-[Brief explanation referencing specific coaching elements]
-[If deal-grounded: How this applies to their specific deal]
-
-Score so far: [X]/[N]
-```
-
-##### QZ-4: Quiz Results
-
-```
-COACHING QUIZ RESULTS
-=====================
-Score: [X]/[Total] ([Percentage]%)
-Category: [Quiz Type]
-Grounding: [Deal-specific: Company Name / Generic Practice]
-
-BREAKDOWN BY COACHING STAGE
-----------------------------
-| Stage | Questions | Correct | Score | Assessment |
-|-------|-----------|---------|-------|------------|
-| Resonate | [N] | [N] | [X]% | [Strong/Adequate/Needs Work] |
-| Elevate  | [N] | [N] | [X]% | [Strong/Adequate/Needs Work] |
-| Compel   | [N] | [N] | [X]% | [Strong/Adequate/Needs Work] |
-
-BREAKDOWN BY COACHING DIMENSION
----------------------------------
-| Dimension | Questions | Correct | Score |
-|-----------|-----------|---------|-------|
-| Buyer Mindset | [N] | [N] | [X]% |
-| Value Propositions | [N] | [N] | [X]% |
-| Talking Points | [N] | [N] | [X]% |
-
-BREAKDOWN BY CATEGORY
-----------------------
-| Category | Questions | Correct | Score |
-|----------|-----------|---------|-------|
-| Stage Recognition | [N] | [N] | [X]% |
-| Methodology Application | [N] | [N] | [X]% |
-| Talk Track Completion | [N] | [N] | [X]% |
-
-STRENGTHS
----------
-[2-3 areas of strong knowledge with specific examples]
-
-GAPS TO FOCUS ON
-----------------
-[2-3 areas needing improvement with specific coaching references]
-
-[For each gap:]
-- Recommended: Practice [Stage] role play with [difficulty]
-- Study: Review [specific section] of frameworks.md
-- Exercise: Try building a [Buyer Mindset / Value Props / Talking Points] for a real deal
-
-RECOMMENDED NEXT STEPS
-----------------------
-1. [Primary recommendation]
-2. [Secondary recommendation]
-3. [Optional stretch recommendation]
-```
-
-After results:
-
-```
-Want to:
-1. Retake this quiz
-2. Take a quiz focused on your weakest area ([Stage])
-3. Practice a role play for your weakest area
-4. Get a coaching microsite for your weakest area
-5. Try a different output mode
-6. Done
-```
+Post-quiz: offer retake, focused quiz on weakest area, role play practice, microsite, mode switch, or done.
 
 ---
 
 ### Step 6: Delivery + Next Actions (CT-6)
 
-After delivering any output, offer iterations:
-
-For **Role Play** and **Quiz**: Next actions are included in RP-4 and QZ-4 above.
+For **Role Play** and **Quiz**: Next actions are included in RP-4 and QZ-4 templates.
 
 For **Microsite** and **Deck**: After opening the HTML file, present:
 
@@ -1042,26 +318,26 @@ Coaching [microsite/deck] generated and opened in your browser.
 
 File: [file path]
 Company: [Company Name or "Generic Practice"]
-Stage: [Resonate / Elevate / Compel] — [Stage subLabel]
+Stage: [Stage] — [subLabel]
 Coaching Agent: [Agent Name]
 Style: [Preset Name]
 
 Want to:
 1. Practice this stage with a role play
-2. Add MEDDPICC deal gap analysis [if not already included]
-3. Move to the next stage ([Next Stage]: [subLabel])
-4. Try a different output mode for this stage
+2. Add MEDDPICC deal gap analysis [if not included]
+3. Move to the next stage ([Next Stage])
+4. Try a different output mode
 5. Regenerate with a different style
 6. Done
 ```
 
-If the user picks option 3 (next stage), return to Step 3b with the next stage pre-selected and flow through Steps 4-5 again.
+If the user picks next stage, return to Step 3b with next stage pre-selected and flow through Steps 4-5.
 
 ---
 
 ## Output Directory
 
-All HTML outputs go to `.octave-deal-coach/` in the project root:
+All HTML outputs go to `.octave-deal-coach/` in the project root (should be in `.gitignore`):
 
 ```
 .octave-deal-coach/
@@ -1071,7 +347,7 @@ All HTML outputs go to `.octave-deal-coach/` in the project root:
     [company-kebab]-deck-[stage].html       # Deck
 ```
 
-This directory should be in `.gitignore`.
+For generic mode, use `practice` instead of company name.
 
 ---
 
@@ -1080,24 +356,20 @@ This directory should be in `.gitignore`.
 ### Research & Enrichment
 | Tool | Purpose |
 |------|---------|
-| `enrich_company` | Company profile, industry, tech stack, strategic context |
-| `find_crm_records` | Deal stage, amount, close date, pipeline position |
-| `find_crm_activities` | Recent interactions — calls, emails, meetings |
+| `enrich_company` | Company profile, industry, tech stack |
+| `find_crm_records` | Deal stage, amount, close date |
+| `find_crm_activities` | Recent interactions |
 | `generate_crm_context` | AI-synthesized CRM narrative |
 
-### Library — Fetching
+### Library
 | Tool | Purpose |
 |------|---------|
 | `get_playbook` | Full playbook with value props, messaging, positioning |
-| `get_entity` | Individual entity details (persona, competitor, proof point) |
-
-### Library — Searching
-| Tool | Purpose |
-|------|---------|
+| `get_entity` | Individual entity details |
 | `search_knowledge_base` | Find matching playbooks, guides, research |
-| `search_resources` | Find relevant resources (docs, presentations) |
+| `search_resources` | Find relevant resources |
 | `list_all_entities` | List personas, competitors, proof points, references |
-| `list_findings` | Objections, pain points, competitor mentions from conversations |
+| `list_findings` | Objections, pain points, competitor mentions |
 | `list_events` | Deal history, stage changes, activity timeline |
 
 ### Content Generation
@@ -1109,28 +381,24 @@ This directory should be in `.gitignore`.
 
 ## Error Handling
 
-> **No CRM data found:** "I couldn't find CRM records for [domain]. I'll proceed with library-level data only. Stage inference will rely on findings and events. You can also manually select a stage."
-
-> **No playbook found:** "No matching playbook found. I'll use general coaching methodology without playbook-specific grounding. Talk tracks will reference the framework but won't include your specific messaging. Consider running `/octave:library` to check your playbook setup."
-
-> **No findings/events:** "No conversation findings or events found for [domain]. Stage inference will rely primarily on CRM stage. For more accurate coaching, ensure conversation data is synced to Octave."
-
-> **Reference file not found:** "Could not load [reference file]. Falling back to general coaching methodology. For full coaching, ensure reference files are in `skills/deal-coach/references/`."
-
-> **Stage inference low confidence:** "I'm not confident about the coaching stage — multiple stages scored similarly. I'd recommend selecting manually. Here are all options: [present all three stages]."
-
-> **MCP connection failed:** "Could not connect to Octave. Check your connection with `/octave:workspace`. Deal coaching requires Octave MCP tools for deal context and library data."
-
-> **HTML write failed:** "Could not write the HTML file. Check that `.octave-deal-coach/` is writable. Try: `mkdir -p .octave-deal-coach`"
+| Condition | Response |
+|-----------|----------|
+| No CRM data | Proceed with library data; inference relies on findings/events; offer manual stage selection |
+| No playbook | Use general methodology; note missing playbook-specific grounding; suggest `/octave:library` |
+| No findings/events | Inference relies primarily on CRM stage; recommend syncing conversation data |
+| Reference file missing | Fall back to general methodology; note the limitation |
+| Low confidence inference | Recommend manual stage selection; present all three stages |
+| MCP connection failed | Direct user to `/octave:workspace` to check connection |
+| HTML write failed | Suggest `mkdir -p .octave-deal-coach` |
 
 ---
 
 ## Related Skills
 
-- `/octave:train` — Generic sales training (role play, quiz, guided learning) without deal coaching methodology
+- `/octave:train` — Generic sales training without deal coaching methodology
 - `/octave:meeting-prep` — Strategic meeting battle plan as HTML
 - `/octave:deck` — General-purpose slide deck builder
 - `/octave:pipeline` — Deal coaching and pipeline management
-- `/octave:enablement` — Sales enablement materials (cheat sheets, objection guides)
+- `/octave:enablement` — Sales enablement materials
 - `/octave:battlecard` — Competitive intelligence and battlecards
 - `/octave:research` — Account and person research

--- a/skills/deal-coach/references/deck-templates.md
+++ b/skills/deal-coach/references/deck-templates.md
@@ -1,0 +1,62 @@
+# Coaching Deck Templates (DK-1 through DK-3)
+
+## DK-1: Style Selection
+
+Same as microsite style selection (see `references/microsite-templates.md` MS-1). Use stage-appropriate default presets.
+
+## DK-2: Slide Outlines by Stage
+
+### Resonate (~7 slides)
+1. Title Slide — "[Company] — Resonate" + stage badge
+2. Stage Context — Deal position, buyer's journey phase, buyer mindset assessment
+3. Buyer Mindset Deep Dive — Awareness level, trigger, constraints, adaptation guidance
+4. Discovery Principles — Go wide, go deep, go high — applied to this deal
+5. Value Propositions — Stage-appropriate props with deployment guidance
+6. Talking Points — Discovery questions and conversation starters with listening cues
+7. Next Steps — Transition checklist to Elevate
+
+### Elevate (~9 slides)
+1. Title Slide — "[Company] — Elevate" + stage badge
+2. Stage Context — Deal position, competitive landscape, buyer mindset
+3. Buyer Mindset Deep Dive — Status quo attachment, change readiness, evaluation mode
+4. The Case for Change — The Shift → The Stakes → The Possibility for this deal
+5. Differentiated Value — What's unique AND important to this buyer
+6. Value Propositions — Value Framing examples (Product → Buyer → Executive voice)
+7. Talking Points — Case for Change talk tracks + differentiation delivery
+8. Proof Points — Evidence grid with deployment guidance
+9. Next Steps — Transition checklist to Compel
+
+### Compel (~9 slides)
+1. Title Slide — "[Company] — Compel" + stage badge
+2. Stage Context — Decision dynamics, stakeholder positions, buyer mindset
+3. Buyer Mindset Deep Dive — Decision process, champion strength, detractors, risk appetite
+4. Before vs. After — Side-by-side with quantified delta
+5. Value Chain — Capability → workflow improvement → business outcome → financial result
+6. Value Propositions — ROI-focused props with quantified outcomes per stakeholder
+7. The Why Now Case — Business urgency + personal urgency
+8. Talking Points — Business case narration + champion enablement scripts
+9. Next Steps — Decision pathway and timeline
+
+Present outline: `Generate?  1. Yes  2. Adjust slides  3. Change style  4. Start over`
+
+## DK-3: HTML Deck Generation
+
+Use slide templates from `references/html-templates.md` for self-contained HTML with scroll-snap slide architecture.
+
+### Viewport Fitting Rules (from `deck/SKILL.md`)
+- ALL font sizes and spacing use `clamp()` — never fixed px
+- Per-slide content limits: Title = 1 heading + 1 subtitle; Content = 1 heading + 4-6 bullets; Grid = max 6 cards
+- If content exceeds limits, split into additional slides
+- `overflow: hidden` on every `.slide`
+- Media queries at 700px, 600px, 500px for short viewports
+
+### Animation
+- Staggered entrance via Intersection Observer (`.animate-in` with opacity + translateY)
+- `nth-child` stagger delays
+- Respect `prefers-reduced-motion`
+
+### Navigation
+- Keyboard: ArrowDown/Up, Space, PageDown/Up
+- Scroll snap for touch/trackpad
+- Progress bar + nav dots
+- Print: `page-break-after: always`, remove snap

--- a/skills/deal-coach/references/microsite-templates.md
+++ b/skills/deal-coach/references/microsite-templates.md
@@ -1,0 +1,110 @@
+# Coaching Microsite Templates (MS-1 through MS-3)
+
+## MS-1: Style Selection
+
+Reference the style preset system from `skills/deck/references/STYLE_PRESETS.md`.
+
+Stage default presets:
+
+| Stage | Default Preset | Rationale |
+|-------|---------------|-----------|
+| Resonate | `soft-light` | Exploratory, calm, trust-building |
+| Elevate | `midnight-pro` | Urgency, disruption, bold contrast |
+| Compel | `executive-dark` | Business gravitas, financial seriousness |
+
+Present with override option:
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "The default style for [Stage] is [preset name] ([rationale]). Want to use it or pick a different style?",
+    header: "Style",
+    options: [
+      { label: "[Default Preset] (Recommended)", description: "[Preset description]" },
+      { label: "Pick a different style", description: "Choose from available presets" },
+      { label: "Auto-pick from brand", description: "Extract colors from the company's website" }
+    ],
+    multiSelect: false
+  }]
+})
+```
+
+If "Pick a different style," present mood-based preview options (follow `deck/SKILL.md` Step 4 pattern).
+
+## MS-2: Content Outline
+
+Present before generating HTML:
+
+```
+COACHING MICROSITE OUTLINE
+==========================
+Company: [Company Name]
+Stage: [Resonate / Elevate / Compel] — [Stage subLabel]
+Coaching Agent: [Agent Name]
+Style: [Preset Name]
+
+STRUCTURE
+---------
+Header + Deal Brief    — Company info, date, coaching stage badge, deal stats grid
+Priority Actions       — 3 quick-hit actions before next meeting (collapsible)
+Deal Activity          — Compact vertical timeline of deal events (collapsible)
+Journey Map            — 3-phase coaching journey showing position + context (collapsible)
+Section 01: Stage Assessment     — Inference evidence, confidence
+Section 02: Buyer Mindset        — Psychology, awareness, triggers, adaptation guidance
+Section 03: Value Propositions   — Stage-appropriate props with deployment + usage notes
+Section 04: Talking Points       — Stage-specific talk tracks (strategic point + quote + evidence)
+Section 05: Objection Handling   — Buyer decision-frame-grounded objections + responses
+Section 06: Next Stage Preview   — Transition checklist + next agent preview
+[Optional] Section 07: Deal Gaps (MEDDPICC) — Coverage assessment + gap-to-action mapping
+The Play               — Strategic one-liner + concrete next action
+
+OCTAVE SOURCES
+--------------
+- Playbook: [Name] | Personas: [N] | Proof Points: [N] | Findings: [N] | Competitors: [N]
+- CRM: [Stage, Amount, Close Date or "Generic mode"]
+
+Generate?  1. Yes  2. Adjust sections  3. Change style  4. Start over
+```
+
+## MS-3: HTML Generation Rules
+
+Use templates from `references/html-templates.md`.
+
+### Content Grounding (from `references/messaging-narratives.md`)
+- Every Value Proposition references specific playbook messaging
+- Every proof point cites a library entity inline with usage note (deploy now / save / already shared)
+- Every Talking Point grounded in deal context, connected to Buyer Mindset
+- Objection responses grounded in the specific decision the buyer is making
+- Use "perspective-shifting question" framing — collaborative, not adversarial
+- Orient language around advancing the deal
+
+### Structural Rules
+- Header + Deal Brief: NOT collapsible — full-width gradient hero with deal stats
+- Priority Actions, Deal Activity, Journey Map: collapsible `<details>` with +/- toggle
+- Sections 01-06 (07 if MEDDPICC): collapsible `<details>`, ALL start COLLAPSED
+- The Play: NOT collapsible — full-width gradient footer
+- No duplicate content between sections; evidence goes inline
+- Talking Points use practical deal-specific headers (NOT framework labels like "The Shift")
+- Use "Coaching Stage: [Name]" badge only (not both "Elevate" and "Evaluate")
+
+### Content Density Limits
+| Section | Limit |
+|---------|-------|
+| Header + Deal Brief | Company info + 4-6 deal stats + stage badge + subtitle |
+| Priority Actions | Exactly 3 actions |
+| Deal Activity | 3-6 timeline entries |
+| Journey Map | 3 phases with generic + deal-specific context |
+| Stage Assessment | 3-4 evidence cards + confidence |
+| Buyer Mindset | Narrative + 3-5 signals + adaptation guidance |
+| Value Propositions | 4-6 props with evidence + usage notes |
+| Talking Points | 4-6 tracks (point + quote + evidence) |
+| Objection Handling | 3-5 objections |
+| Next Stage Preview | 1 checklist + agent preview |
+| Deal Gaps (MEDDPICC) | 8 elements + gap-to-action (if included) |
+| The Play | 1 strategic sentence + 1 action |
+
+### Design Principles
+- Three coaching outputs (Buyer Mindset, Value Props, Talking Points) are the organizing principle
+- Talk tracks: strategic point (bold, practical) → sample quote (italic) → "Use when..." guidance
+- MEDDPICC is optional, not primary structure
+- No duplicate content; each piece appears once

--- a/skills/deal-coach/references/quiz-templates.md
+++ b/skills/deal-coach/references/quiz-templates.md
@@ -1,0 +1,124 @@
+# Interactive Quiz Templates (QZ-1 through QZ-4)
+
+## QZ-1: Quiz Setup
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "What type of coaching quiz do you want?",
+    header: "Quiz Type",
+    options: [
+      { label: "Stage Recognition", description: "Buyer says X — which coaching stage? Tests deal diagnosis." },
+      { label: "Methodology Application", description: "You're in [Stage] — what's the right approach? Tests methodology." },
+      { label: "Talk Track Completion", description: "Buyer raises objection — what's your methodology-backed response?" },
+      { label: "Full Review", description: "Mix of all categories across Resonate, Elevate, and Compel." }
+    ],
+    multiSelect: false
+  },
+  {
+    question: "How many questions?",
+    header: "Length",
+    options: [
+      { label: "Quick (5)", description: "5-10 minutes" },
+      { label: "Standard (10)", description: "15-20 minutes" },
+      { label: "Deep (15)", description: "25-30 minutes" }
+    ],
+    multiSelect: false
+  }]
+})
+```
+
+## QZ-2: Question Bank Structure
+
+Load coaching content from reference files. Ground in deal data (deal-specific) or playbook data (generic).
+
+### Stage Recognition
+- Present buyer quote/scenario → ask which stage
+- Use findings and CRM data for realistic scenarios
+- Include red herrings (scenarios that seem like one stage but are another)
+
+### Methodology Application
+- Name a stage → ask for the right approach
+- E.g., "You're in Elevate. What are the three beats of the Case for Change?"
+- Test Buyer Mindset → Value Props → Talking Points mapping
+
+### Talk Track Completion
+- Present buyer statement → ask for methodology-backed response
+- E.g., "Buyer: 'We're happy with what we have.' Using Elevate methodology, what next?"
+- Score on methodology adherence AND natural delivery
+
+### Full Review
+- Mix all categories, weight toward selected/inferred stage
+- Ensure coverage across all three stages
+
+## QZ-3: Question Presentation
+
+```
+QUESTION [N]/[Total]
+Category: [Stage Recognition / Methodology Application / Talk Track Completion]
+Stage: [Resonate / Elevate / Compel]
+[If deal-grounded: "Based on your [Company] deal"]
+
+[Question text]
+[Multiple choice: 4 options | Open-ended: free response]
+```
+
+After each answer:
+```
+[Correct / Partially Correct / Incorrect]
+[Explanation referencing coaching elements + deal application]
+Score so far: [X]/[N]
+```
+
+## QZ-4: Results Template
+
+```
+COACHING QUIZ RESULTS
+=====================
+Score: [X]/[Total] ([Percentage]%)
+Category: [Quiz Type]
+Grounding: [Company Name / Generic Practice]
+
+BREAKDOWN BY COACHING STAGE
+| Stage | Questions | Correct | Score | Assessment |
+|-------|-----------|---------|-------|------------|
+| Resonate | [N] | [N] | [X]% | [Strong/Adequate/Needs Work] |
+| Elevate  | [N] | [N] | [X]% | [Strong/Adequate/Needs Work] |
+| Compel   | [N] | [N] | [X]% | [Strong/Adequate/Needs Work] |
+
+BREAKDOWN BY COACHING DIMENSION
+| Dimension | Questions | Correct | Score |
+|-----------|-----------|---------|-------|
+| Buyer Mindset | [N] | [N] | [X]% |
+| Value Propositions | [N] | [N] | [X]% |
+| Talking Points | [N] | [N] | [X]% |
+
+BREAKDOWN BY CATEGORY
+| Category | Questions | Correct | Score |
+|----------|-----------|---------|-------|
+| Stage Recognition | [N] | [N] | [X]% |
+| Methodology Application | [N] | [N] | [X]% |
+| Talk Track Completion | [N] | [N] | [X]% |
+
+STRENGTHS
+[2-3 areas of strong knowledge with examples]
+
+GAPS TO FOCUS ON
+[2-3 areas needing improvement with coaching references]
+Per gap: recommended practice mode, study section, exercise suggestion.
+
+RECOMMENDED NEXT STEPS
+1. [Primary] 2. [Secondary] 3. [Optional stretch]
+```
+
+## Post-Quiz Options
+
+```
+Want to:
+1. Retake this quiz
+2. Take a quiz focused on your weakest area ([Stage])
+3. Practice a role play for your weakest area
+4. Get a coaching microsite for your weakest area
+5. Try a different output mode
+6. Done
+```

--- a/skills/deal-coach/references/roleplay-templates.md
+++ b/skills/deal-coach/references/roleplay-templates.md
@@ -1,0 +1,209 @@
+# Role Play Templates (RP-1 through RP-4)
+
+## RP-1: Scenario Setup
+
+Present scenario options:
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "What kind of role play do you want?",
+    header: "Scenario",
+    options: [
+      { label: "Single Stage Practice", description: "Practice one stage in a focused 8-12 exchange conversation" },
+      { label: "Full Journey Simulation", description: "Walk through Resonate → Elevate → Compel in sequence" }
+    ],
+    multiSelect: false
+  },
+  {
+    question: "How difficult should the buyer be?",
+    header: "Difficulty",
+    options: [
+      { label: "Friendly", description: "Buyer is open and receptive" },
+      { label: "Skeptical", description: "Buyer pushes back moderately" },
+      { label: "Hostile", description: "Buyer is resistant or aggressive" }
+    ],
+    multiSelect: false
+  }]
+})
+```
+
+If deal-specific, identify buyer persona from entities. If generic, let user choose:
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "Which persona should the buyer represent?",
+    header: "Buyer Persona",
+    options: [
+      // Dynamically populated from list_all_entities({ entityType: "persona" })
+      { label: "[Persona Name]", description: "[Persona title/role]" }
+      // ... up to 4 personas
+    ],
+    multiSelect: false
+  }]
+})
+```
+
+## RP-2: Stage-Specific Buyer Behavior Rules
+
+Load the coaching agent's rubric and grounding map. Map Octave data via `references/messaging-narratives.md` (deal-specific) or use playbook-level data (generic).
+
+| Stage | Buyer Psychology | Behavior Rules |
+|-------|-----------------|---------------|
+| Resonate | Exploratory, guarded | Shares surface problems, tests whether seller digs deeper. Friendly: volunteers info. Hostile: one-word answers. |
+| Elevate | Status quo defender / comparison shopper | Resists change, references competitors. Friendly: open to new perspective. Hostile: "We've been doing fine for years" / "Your competitor does that too." |
+| Compel | Analytical, needs numbers, risk-averse | Asks about ROI, pushes back on vague claims. Friendly: engages with data. Hostile: "Those numbers don't apply to us" / "Now is not the right time." |
+
+## RP-3: Scene Template
+
+```
+=======================================
+DEAL COACHING ROLE PLAY: [Stage]
+=======================================
+
+THE SCENE
+---------
+You are a seller from [company/product] meeting with [Persona Name], [Title] at [Company].
+[If deal-specific: Brief deal context from CRM]
+[If generic: Practice scenario description]
+
+COACHING STAGE: [Resonate / Elevate / Compel]
+[Stage subLabel]
+
+Your goal is to demonstrate strong execution across:
+- Buyer Mindset — accurately read and adapt to the buyer
+- Value Propositions — deploy the right props for this stage
+- Talking Points — execute the stage's methodology naturally
+
+BUYER PROFILE
+- Name: [Persona Name]
+- Role: [Title]
+- Mindset: [Stage-appropriate psychology]
+- Difficulty: [Friendly/Skeptical/Hostile]
+
+RULES
+-----
+1. This is a CONVERSATION — respond naturally as the seller
+2. I will play [Persona Name] with [difficulty]-level resistance
+3. The conversation will run 8-12 exchanges
+4. You'll be scored on Buyer Mindset, Value Props, and Talking Points
+5. I'll signal when the conversation is wrapping up
+6. Stay in character — no breaking the fourth wall
+
+Ready? I'll start as [Persona Name]...
+=======================================
+```
+
+**Buyer play rules:**
+- Adjust resistance based on difficulty level
+- Drop stage-relevant cues a well-trained seller should pick up on
+- Friendly: verbal rewards for correct methodology. Skeptical: push back on weak points. Hostile: resist aggressively, only yield to excellent execution.
+- After 8-12 exchanges, signal wrap-up: "I think we're running short on time..."
+
+**Full Journey Simulation:** Start at Resonate, progress through each stage. Pause between stages: "Good — let's fast-forward." Score each stage independently, then cumulative.
+
+## RP-4: Coaching Scorecard
+
+```
+DEAL COACHING SCORECARD
+=======================
+Stage: [Resonate / Elevate / Compel]
+Coaching Agent: [Agent Name]
+Difficulty: [Friendly/Skeptical/Hostile]
+Persona: [Buyer Name], [Title]
+
+BUYER MINDSET
+-------------
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| Awareness read | [1-5] | [Did they correctly assess where the buyer is?] |
+| Adaptation | [1-5] | [Did they adjust their approach based on buyer signals?] |
+| Psychology match | [1-5] | [Did they match the buyer's emotional state before trying to move it?] |
+
+Buyer Mindset Score: [avg]/5
+
+VALUE PROPOSITIONS
+------------------
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| Stage appropriateness | [1-5] | [Did they use props fitting for this stage?] |
+| Selection quality | [1-5] | [Did they pick the most impactful props available?] |
+| Deployment timing | [1-5] | [Did they introduce props at the right moment?] |
+
+Value Propositions Score: [avg]/5
+
+TALKING POINTS
+--------------
+[Use stage-specific criteria from coaching-agents.md]
+
+Resonate:
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| Going wide | [1-5] | [Map the landscape — stakeholders, history, context] |
+| Going deep | [1-5] | [Find root causes, not just symptoms] |
+| Going high | [1-5] | [Connect to business and personal impact] |
+| Problem statement quality | [1-5] | [Multi-dimensional problem articulation] |
+
+Elevate:
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| Case for Change delivery | [1-5] | [Three beats — Shift, Stakes, Possibility] |
+| Value Framing | [1-5] | [Buyer/Executive voice, not Product voice] |
+| Differentiation quality | [1-5] | [Differentiated value focus] |
+| Proof point usage | [1-5] | [Specific, credible proof] |
+
+Compel:
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| Business case quality | [1-5] | [Co-created quantified value] |
+| Value chain clarity | [1-5] | [Capability → outcome → dollars] |
+| Why Now execution | [1-5] | [Business and personal urgency] |
+| Champion enablement | [1-5] | [Armed the champion] |
+
+Talking Points Score: [avg]/5
+
+GENERAL SELLING SKILLS
+----------------------
+| Element | Score | Notes |
+|---------|-------|-------|
+| Opening / rapport | [1-5] | [Assessment] |
+| Active listening | [1-5] | [Assessment] |
+| Proof point usage | [1-5] | [Assessment] |
+| Call control | [1-5] | [Assessment] |
+| Natural delivery | [1-5] | [Assessment] |
+
+OVERALL SCORE: [X]/5
+Buyer Mindset: [avg]/5 | Value Props: [avg]/5 | Talking Points: [avg]/5 | General: [avg]/5
+
+KEY MOMENTS
+-----------
+[Quote from conversation + assessment — 3-5 key moments]
+
+COACH SAYS
+----------
+[2-3 paragraphs of specific coaching from the stage's coaching agent persona.
+Reference specific Talking Points from frameworks.md.
+Ground in the seller's playbook messaging.
+Identify #1 area for improvement with a concrete alternative.]
+
+VALUE PROPS YOU COULD HAVE USED
+-------------------------------
+[3-5 value props from the library with:
+- The prop itself
+- When to deploy it (which conversation moment)
+- How to frame it for this stage (Buyer/Executive voice)]
+```
+
+## Post-Scorecard Options
+
+```
+Want to:
+1. Run this role play again (same stage, same difficulty)
+2. Try a harder difficulty level
+3. Practice the next stage ([Next Stage])
+4. Practice objection handling for this stage
+5. Get a coaching microsite for this stage
+6. Switch to a different output mode
+7. Done
+```

--- a/skills/meeting-prep/SKILL.md
+++ b/skills/meeting-prep/SKILL.md
@@ -1,22 +1,13 @@
 ---
 name: meeting-prep
-description: Strategic meeting battle plan with coaching frameworks, scripted talk tracks, and a phase-by-phase game plan — rendered as self-contained HTML. Use when user says "meeting prep", "battle plan", "prep me for my meeting", "prep for my call", or wants a coached game plan for an upcoming meeting. Do NOT use for account reference documents — use /octave:brief instead.
+description: "Strategic meeting battle plan with coaching frameworks, scripted talk tracks, and a phase-by-phase game plan — rendered as self-contained HTML. Use when user says 'meeting prep', 'battle plan', 'prep me for my meeting', 'prep for my call', or wants a coached game plan for an upcoming meeting. Do NOT use for account reference documents — use /octave:brief instead."
 ---
 
 # /octave:meeting-prep - Strategic Meeting Battle Plan
 
 Build a coached, strategic meeting battle plan rendered as a self-contained HTML document. Unlike `/octave:brief` (a reference dossier), this skill produces a battle plan — combining Octave intelligence with coaching frameworks to generate belief stacks, scripted talk tracks, discovery questions, a stakeholder map, landmine warnings, and a phase-by-phase game plan timed to your meeting duration.
 
-The skill reads two coaching reference files at runtime:
-- `references/strategic-coach.md` — Enterprise strategic sales coaching (belief stacking, ecosystem positioning, Socratic discovery)
-- `references/positioning-coach.md` — Product positioning coaching based on April Dunford's methodology (positioned sales pitch, competitive alternatives, feature-value-emotion ladder)
-
-If a user replaces these files with their own coaching frameworks, the skill adapts automatically.
-
-**Key differentiators:**
-- vs `/octave:brief` — brief is a reference dossier; meeting-prep is a coached battle plan with talk tracks and a timed game plan
-- vs `/octave:research` — research outputs plain text; meeting-prep renders a styled HTML document with coaching intelligence
-- vs `/octave:deck` — deck is a slide presentation for the audience; meeting-prep is internal prep for the seller
+Reads two coaching reference files at runtime: `references/strategic-coach.md` (belief stacking, ecosystem positioning, Socratic discovery) and `references/positioning-coach.md` (April Dunford's positioned sales pitch, competitive alternatives, feature-value-emotion ladder). If a user replaces these with their own coaching frameworks, the skill adapts automatically.
 
 ## Usage
 
@@ -24,28 +15,7 @@ If a user replaces these files with their own coaching frameworks, the skill ada
 /octave:meeting-prep <target> [--type <meeting-type>] [--style <preset>]
 ```
 
-## Examples
-
-```
-/octave:meeting-prep acme.com                                    # General meeting prep
-/octave:meeting-prep jane@acme.com --type discovery              # Discovery call battle plan
-/octave:meeting-prep acme.com --type demo                        # Demo prep with talk tracks
-/octave:meeting-prep acme.com --type executive                   # Executive meeting with board framing
-/octave:meeting-prep jane@acme.com --type follow-up              # Follow-up with prior call context
-/octave:meeting-prep acme.com --type qbr --style executive-dark  # QBR prep with specific style
-/octave:meeting-prep "meeting with VP Sales at Acme"             # Context-based prep
-```
-
-## Meeting Types
-
-| Type | Primary Focus |
-|------|--------------|
-| `discovery` | Discovery questions primary, belief framework, qualification |
-| `demo` | Positioned pitch tailored to demo flow, demo landmines |
-| `follow-up` | Updated pain from prior calls, deal advancement |
-| `executive` | Concise TL;DR, executive talk tracks, board-level framing |
-| `qbr` | Value delivered, renewal/expansion angles |
-| `general` | Balanced all sections (default) |
+**Meeting types:** `discovery` (questions + beliefs + qualification), `demo` (positioned pitch + demo landmines), `follow-up` (updated pain + deal advancement), `executive` (TL;DR + board-level framing), `qbr` (value delivered + expansion), `general` (balanced, default).
 
 ## Instructions
 
@@ -59,248 +29,62 @@ When the user runs `/octave:meeting-prep`:
 - LinkedIn URL -> Person-targeted prep
 - Meeting description -> Extract company/people from context
 
-**1.2 Detect or ask meeting type:**
+**1.2** If `--type` not specified, ask: meeting type (discovery/demo/follow-up/executive/qbr/general), duration (30/45/60/90 min), prior context (transcript/notes/none), and attendees (names+roles or "unknown"). If attendees unknown, build a general stakeholder map from Octave contacts. If user provides a transcript or notes, synthesize alongside Octave data.
 
-If `--type` not specified, infer from context or ask:
+**1.3 Read coaching reference files** from the skill directory:
+- `references/strategic-coach.md` — belief stacking, ecosystem positioning, enhancement framing, guardrail reframe, Socratic discovery
+- `references/positioning-coach.md` — positioned sales pitch (5 steps), feature→value→emotion, competitive alternatives, category framing, language mining
 
-```
-What type of meeting are you prepping for?
-
-1. Discovery — First conversation, qualifying the opportunity
-2. Demo — Showing the product, proving value
-3. Follow-up — Continuing a conversation, advancing the deal
-4. Executive — High-level strategic conversation
-5. QBR — Quarterly business review with existing customer
-6. General — Balanced battle plan (default)
-
-Your choice:
-```
-
-**1.3 Ask meeting duration:**
-
-The duration drives the game plan timeline — phases get proportional time allocations.
-
-```
-How long is this meeting?
-
-1. 30 minutes
-2. 45 minutes
-3. 60 minutes
-4. 90 minutes
-
-Your choice:
-```
-
-**1.4 Collect user context:**
-
-Ask if the user has any prior context to incorporate:
-
-```
-Do you have any prior context to fold in?
-
-1. Call transcript or recording notes
-2. Email thread or meeting notes
-3. My own notes / talking points
-4. No prior context — use Octave intel + coaching frameworks
-
-Paste or describe (or press Enter to skip):
-```
-
-If the user provides a transcript, notes, or email thread, synthesize that context alongside Octave data. If they skip, proceed with Octave intel and coaching frameworks only.
-
-**1.5 Identify attendees:**
-
-```
-Who's attending? (names, titles, emails — or "I don't know yet")
-```
-
-If attendees are unknown, build a general stakeholder map from Octave contacts.
-
-**1.6 Read coaching reference files:**
-
-Read the two coaching reference files from the skill directory:
-- `references/strategic-coach.md` — Extract: belief stacking, ecosystem positioning, enhancement framing, ideal customer fit, guardrail reframe, Socratic discovery
-- `references/positioning-coach.md` — Extract: positioned sales pitch (5 steps), feature→value→emotion, competitive alternatives, category framing, language mining, heads on pillows test
-
-If the files are not found, fall back to general sales coaching best practices.
+Fall back to general sales coaching best practices if files not found.
 
 ### Step 2: Octave Context Gathering
 
-Based on the target and meeting type, use Octave MCP tools to build a complete intelligence picture. **Tell the user what you're researching and why.**
+Layer multiple intelligence sources to build a thorough battle plan. **Tell the user what you're researching and why.**
 
-**Call as many tools as needed to build a thorough battle plan.** The best meeting preps layer multiple sources — company enrichment + person enrichment + playbook messaging + proof points + conversation intel + coaching frameworks all combine to create a document grounded in real data. Don't stop at one tool when several would give you a stronger prep.
-
-Not every tool applies to every meeting. Use your judgment about which are relevant to *this specific* situation. The tables below show what's available — pick the combination that gives you the richest context for the meeting type and target.
-
-**List vs Search — when to use which:**
-
-| Tool | Purpose | Use when... |
-|------|---------|-------------|
-| `list_all_entities({ entityType })` | Fetch all entities of a type (minimal fields) | You want a quick inventory — "show me all our competitors" |
-| `list_entities({ entityType })` | Fetch entities with full data (paginated) | You need the actual content — "get full proof point details" |
-| `get_entity({ oId })` | Deep dive on one specific entity | You found something relevant and need the complete picture |
-| `search_knowledge_base({ query })` | Semantic search across library + resources | You have a concept or question — "how do we position for healthcare?" |
-| `list_resources()` / `search_resources({ query })` | Uploaded docs, URLs, Google Drive files | You need reference material, uploaded assets, or source docs |
-
-**Rule of thumb:** Use `list_*` when you know *what type* of thing you want. Use `search_*` when you know *what topic* you're looking for.
-
-**Findings and events — always attempt, gracefully skip:**
-
-ALWAYS try to pull findings and events if you have a company domain or contact emails. Use a 90-day window. If data exists, it populates the "Prior Intelligence" section. If not, silently omit — no error message.
-
-- `list_findings({ query: "<company or contact>", startDate: "<90 days ago>" })` — surfaces what was actually said in calls: objections raised, features requested, pain points confirmed, competitor mentions
-- `list_events({ filters: { accounts: ["<account_oId>"] } })` — deal stage changes, meetings held, emails sent
-- `get_event_detail({ eventOId })` — deep dive on specific past interactions
-
----
-
-#### For Person-Targeted Preps
-
-Start with person and company enrichment, then pull positioning context:
-
-| What you need | Tool | When to use |
-|---------------|------|-------------|
-| Person deep-dive | `enrich_person({ person: { email, firstName, lastName, companyDomain } })` | Always for person-targeted preps — gives background, role, priorities |
-| Company profile | `enrich_company({ companyDomain })` | Always — gives industry, size, tech stack, signals |
-| ICP fit (person) | `qualify_person({ person: { ... } })` | When you need persona match and fit assessment |
-| ICP fit (company) | `qualify_company({ companyDomain })` | When you need segment match and ICP scoring |
-| Additional contacts | `find_person({ searchMode: "people", companyDomain, fuzzyTitles })` | When you want to map the broader buying committee |
-| Matching playbook | `get_playbook({ oId, includeValueProps: true })` | After identifying relevant playbook — full strategy + value props |
-| Playbook search | `search_knowledge_base({ query: "<industry> <persona>", entityTypes: ["playbook"] })` | When you need the best-fit playbook by concept |
-| Proof points | `list_entities({ entityType: "proof_point" })` | Fetch all proof points with full data — metrics, quotes, logos |
-| References | `list_entities({ entityType: "reference" })` | Customer references with full details |
-| Competitive context | `search_knowledge_base({ query: "<signals>", entityTypes: ["competitor"] })` | When competitor is mentioned or likely in the deal |
-| Recent intel | `list_findings({ query: "<company or person>", startDate: "<90 days ago>" })` | Conversation-based insights from past interactions |
-| Deal history | `list_events({ filters: { accounts: ["<account_oId>"] } })` | Timeline of deal events |
-| Synthesized prep | `generate_call_prep({ companyDomain })` | Quick comprehensive brief to use as a starting point |
-
----
-
-#### For Company-Targeted Preps
-
-Start with company enrichment and contact discovery:
-
-| What you need | Tool | When to use |
-|---------------|------|-------------|
-| Company profile | `enrich_company({ companyDomain })` | Always — gives industry, size, tech stack, funding, signals |
-| ICP fit scoring | `qualify_company({ companyDomain })` | Always — segment match, fit score, fit reasons |
-| Key contacts | `find_person({ searchMode: "people", companyDomain, fuzzyTitles })` | Find stakeholders to populate the Stakeholder Map |
-| Enrich contacts | `enrich_person({ person: { ... } })` | Deep dive on each key contact found |
-| All playbooks | `list_all_entities({ entityType: "playbook" })` | Quick scan to find the right strategic approach |
-| Playbook details | `get_playbook({ oId, includeValueProps: true })` | Full content + value props for the matching playbook |
-| Value props | `list_value_props({ playbookOId })` | Fetch value props for the recommended playbook |
-| All competitors | `list_all_entities({ entityType: "competitor" })` | Quick scan of competitive landscape |
-| Competitor details | `get_entity({ oId })` | Deep dive on a specific relevant competitor |
-| Proof points | `list_entities({ entityType: "proof_point" })` | Full proof points for the evidence section |
-| References | `list_entities({ entityType: "reference" })` | Customer references for social proof |
-| Topic search | `search_knowledge_base({ query: "<industry> <use case>", entityTypes: ["proof_point", "reference"] })` | Find proof points relevant to their specific situation |
-| Recent intel | `list_findings({ query: "<company>", startDate: "<90 days ago>" })` | Conversation signals from calls and meetings |
-| Deal events | `list_events({ filters: { accounts: ["<account_oId>"] } })` | Full deal history and timeline |
-| Event details | `get_event_detail({ eventOId })` | Deep dive on specific past interactions |
-| Uploaded resources | `search_resources({ query: "<company or industry>" })` | Relevant uploaded docs and assets |
-
----
-
-**Output of this step:** Present a content outline to the user for approval before generating:
-
+**Person-targeted prep** (email/LinkedIn):
 ```
-BATTLE PLAN OUTLINE: [Company/Person] — [Meeting Type]
-========================================================
-
-Target: [Company name / Person name at Company]
-Meeting Type: [Discovery / Demo / Follow-up / Executive / QBR / General]
-Duration: [30 / 45 / 60 / 90] minutes
-Attendees: [Names and roles, or "General stakeholder map"]
-Style: [Will be selected in Step 3]
-
----
-
-SECTIONS TO INCLUDE
--------------------
-
-1. Header — Meeting details, date, duration, attendees
-2. TL;DR — 2-3 sentence opportunity summary
-3. Stakeholder Map — Buying roles: budget owner, champion, evaluator, gatekeeper
-4. Their Pain — By stakeholder/theme, from context + enrichment
-5. What They Need to Believe — Belief stack with proof status
-6. Positioned Sales Pitch — 5-step scripted talk track
-7. Discovery Questions — Segmented by stakeholder, meeting-type-aware
-8. Landmines & Watch-Outs — Risk/mitigation pairs, competitive traps
-9. Coach's Corner — Strategic + positioning coach perspectives
-10. Meeting Game Plan — Timeline phased to [duration] minutes
-11. Deal Intelligence — Budget, champion, decision maker, compelling event
-12. The Line — One memorable sentence
-
-Octave Sources Used:
-- Company enrichment: [Company] — [key insights]
-- Person enrichment: [Person] — [persona match]
-- Playbook: [Playbook name] — [strategic angle]
-- Proof points: [N] references pulled
-- Findings: [N] recent signals (or "none found — skipped")
-- Competitive: [If applicable]
-- User context: [Transcript / notes / none]
-
----
-
-Does this look good? I can:
-1. Proceed to style selection and generation
-2. Add or remove sections
-3. Go deeper on any area
-4. Change the meeting type or emphasis
+enrich_person({ email: "jane@acme.com" })          # Role, seniority, social profiles
+enrich_company({ domain: "acme.com" })              # Company context, size, industry
+list_findings({ personOId: "<oId>", days: 90 })     # Recent conversation signals
 ```
 
-**Wait for user approval before proceeding.**
+**Company-targeted prep** (domain):
+```
+enrich_company({ domain: "acme.com" })              # Company intelligence
+list_all_entities({ entityType: "persona" })         # Match attendees to personas
+search_knowledge_base({ query: "acme challenges" })  # Relevant library intelligence
+```
+
+**Always attempt** (gracefully skip if empty):
+```
+get_playbook({ oId: "<playbook_oId>" })              # Messaging, value props, talk tracks
+list_value_props({ playbookOId: "<oId>" })           # Persona-specific value props
+list_findings({ companyOId: "<oId>", days: 90 })     # Conversation evidence
+list_events({ companyOId: "<oId>", days: 90 })       # Recent activity signals
+search_knowledge_base({ query: "<competitor>" })     # Competitive context
+```
+
+See `references/mcp-tool-reference.md` for the full tool catalog.
+
+---
+
+**Output of this step:** Present a content outline listing: target, meeting type, duration, attendees, the 12 sections to include (Header, TL;DR, Stakeholder Map, Their Pain, What They Need to Believe, Positioned Sales Pitch, Discovery Questions, Landmines & Watch-Outs, Coach's Corner, Meeting Game Plan, Deal Intelligence, The Line), and Octave sources used. Ask user to approve, add/remove sections, or go deeper before proceeding.
 
 ### Step 3: Style Selection
 
-The battle plan uses the same CSS variable / style preset system as `/octave:deck`. Full preset definitions are in the deck skill's [STYLE_PRESETS.md](../deck/STYLE_PRESETS.md).
+Uses the same CSS variable / style preset system as `/octave:deck`. Full presets in [STYLE_PRESETS.md](../deck/STYLE_PRESETS.md). If `--style` not provided, offer: `midnight-pro` (default), `paper-minimal`, `executive-dark`, `soft-light`, `swiss-modern`, "Use my brand", or "Match my deck".
 
-Battle plans default to readability-optimized presets. If `--style` was not provided, ask:
-
-```
-Pick a style for your battle plan:
-
-1. midnight-pro     — Dark navy, white text, blue accents (default)
-2. paper-minimal    — Off-white, black type, editorial simplicity
-3. executive-dark   — Charcoal + gold, premium boardroom aesthetic
-4. soft-light       — Warm white + sage green, calm and approachable
-5. swiss-modern     — White + red accent, Bauhaus minimal
-6. Use my brand     — Extract from website or provide colors
-7. Match my deck    — Use the same style as an existing /octave:deck
-
-Your choice (or press Enter for default):
-```
-
-| Meeting Type | Recommended Default |
-|--------------|-------------------|
-| Discovery | `midnight-pro` |
-| Demo | `midnight-pro` |
-| Follow-up | `midnight-pro` |
-| Executive | `executive-dark` |
-| QBR | `executive-dark` |
-| General | `midnight-pro` |
-
-If the user selects "Use my brand," follow the brand discovery flow from the deck skill (website extraction via browser-use or WebFetch, manual fallback). If they select "Match my deck," ask for the deck file path and extract its CSS variables.
+Default by meeting type: Executive and QBR use `executive-dark`; all others use `midnight-pro`. For "Use my brand," follow the deck skill's brand discovery flow. For "Match my deck," extract CSS variables from the existing deck file.
 
 ### Step 4: Generate HTML
 
 Build a single self-contained HTML file. The battle plan is a scrollable reference document — not a slide deck. Natural page scroll, sticky sidebar navigation, collapsible sections, and a print-friendly layout.
 
-#### Output Directory
+See `references/battle-plan-template.html` for the full HTML scaffold, CSS architecture, and component patterns (sidebar nav, collapsible sections, cards, badges, grids, print/responsive styles).
 
-```
-.octave-meeting-prep/
-└── <kebab-case-name>-<YYYY-MM-DD>/
-    └── <name>.html
-```
+#### Meeting Type -> Section Emphasis
 
-Example: `/octave:meeting-prep acme.com --type discovery` -> `.octave-meeting-prep/acme-discovery-2026-02-27/acme-discovery.html`
-
-The `.octave-meeting-prep/` directory should be in `.gitignore`.
-
-#### Meeting Type → Section Emphasis
-
-Not all sections are equally weighted in every meeting type. The type determines emphasis:
+Not all sections are equally weighted in every meeting type:
 
 | Meeting Type | Emphasized Sections | De-emphasized / Condensed |
 |--------------|-------------------|---------------------------|
@@ -313,699 +97,48 @@ Not all sections are equally weighted in every meeting type. The type determines
 
 #### Document Sections (12 total)
 
-**1. Header**
-Meeting title, generation date, meeting type badge (pill label like "Discovery Battle Plan" or "Executive Prep"), duration badge, attendee list with roles.
+**1. Header** — Meeting title, date, type badge, duration badge, attendee list with roles.
 
-**2. TL;DR**
-2-3 sentence opportunity summary. What's the situation, what's at stake, what's the play. Scannable in 10 seconds.
+**2. TL;DR** — 2-3 sentence opportunity summary. What's the situation, what's at stake, what's the play.
 
-**3. Stakeholder Map**
-Cards for each attendee or known contact, tagged with buying role:
-- **Budget Owner** — Controls the money
-- **Champion** — Internal advocate, wants you to win
-- **Evaluator** — Technical or functional gatekeeper
-- **Gatekeeper** — Controls access to decision makers
+**3. Stakeholder Map** — Cards for each attendee tagged with buying role (Budget Owner, Champion, Evaluator, Gatekeeper). Each card: name, title, LinkedIn URL, inferred priorities, communication style, what they care about.
 
-Each card: name, title, LinkedIn URL (if known), inferred priorities, communication style notes, what they care about.
+**4. Their Pain** — Pain points by stakeholder or theme, drawn from user context, Octave enrichment, findings, and playbook personas. Each: the pain (their words when possible), business impact, your response.
 
-**4. Their Pain**
-Pain points organized by stakeholder or by theme, drawn from:
-- User-provided context (transcript, notes, email thread)
-- Octave enrichment data
-- Findings from prior conversations
-- Persona pain points from matching playbook
+**5. What They Need to Believe** — Belief stacking from `strategic-coach.md`: 5-6 sequential beliefs, each rated Proven/Mostly Proven/Needs Proof with evidence. Color-coded status (green/yellow/red). Highlight weakest links as meeting priorities.
 
-Each pain point: the pain (their words when possible), the business impact, your response.
+**6. Positioned Sales Pitch** — 5-step pitch from `positioning-coach.md` scripted for this meeting: (1) Set status quo, (2) Name the problem, (3) Introduce the category, (4) Position in category, (5) Proof. Each step has a talk track plus coaching note. Apply feature->value->emotion ladder for every product mention.
 
-**5. What They Need to Believe**
-Apply the belief stacking framework from `strategic-coach.md`:
-- 5-6 sequential beliefs, each building on the previous
-- Each rated: Proven / Mostly Proven / Needs Proof
-- Evidence or proof point for each
-- Highlight the weakest links — these are the meeting priorities
+**7. Discovery Questions** — 8-12 questions max, segmented by stakeholder or category. Meeting-type-aware: Discovery=full battery, Demo=landmine/confirmation, Follow-up=progress/blockers, Executive=strategic/vision, QBR=value/expansion. Each with coaching note on what the answer reveals.
 
-Visual: color-coded status (green = Proven, yellow = Mostly Proven, red = Needs Proof).
+**8. Landmines & Watch-Outs** — 4-6 risk/mitigation pairs: competitive traps, likely objections with coached responses, topics to avoid, signals to watch for. Two-column layout.
 
-**6. Positioned Sales Pitch**
-Apply the 5-step positioned sales pitch from `positioning-coach.md`, scripted for this specific meeting:
-1. Set the status quo — "Here's what we see in your world..."
-2. Name the problem — "But as [trigger], [what breaks]..."
-3. Introduce the category — "That's why [category] exists..."
-4. Position in the category — "[Product] is the [differentiator] [category]..."
-5. Proof — "[Similar customer] saw [result]..."
+**9. Coach's Corner** — Two perspectives from coaching frameworks. Strategic Coach: ecosystem positioning, enhancement framing, ideal customer fit, guardrail reframe. Positioning Coach: category framing, competitive alternatives, language mining, heads on pillows test. 3-4 bullets each.
 
-Each step includes a scripted talk track (actual words to say) plus a coaching note on delivery. Apply the feature→value→emotion ladder from the positioning framework for every product mention.
+**10. Meeting Game Plan** — Phase-by-phase timeline matched to meeting duration. See `references/game-plan-timing.md` for the full time allocation tables (30/45/60/90 min). Each phase: what to say, what to listen for, transition line.
 
-**7. Discovery Questions**
-Segmented by stakeholder (if attendees are known) or by category. Meeting-type-aware:
-- Discovery: full question battery (diagnostic, forcing-function, accountability from `strategic-coach.md`)
-- Demo: landmine questions, confirmation questions, "what would make this real?" questions
-- Follow-up: progress questions, blocker questions, expansion questions
-- Executive: strategic questions, vision questions, decision criteria
-- QBR: value realization, adoption, expansion opportunity
+**11. Deal Intelligence** — Budget, Champion, Decision Maker, Compelling Event, Competition, Stage, Next Milestone. If no deal data exists (new prospect), flag what to uncover in this meeting.
 
-8-12 questions max. Each with a brief coaching note on what the answer reveals.
+**12. The Line** — One memorable sentence capturing the strategic essence. The sticky-note insight for your monitor before the call. Examples: "They believe the problem exists but don't believe anyone's solved it — that's your opening." / "The VP is bought in; the Director needs proof it won't break their workflow."
 
-**8. Landmines & Watch-Outs**
-Risk/mitigation pairs:
-- Competitive traps (things the competitor wants them to ask about)
-- Objections likely to surface (with coached responses)
-- Topics to avoid or defer
-- Signals to watch for (body language, tone shifts, questions they ask)
+#### Content Limits
 
-Visual: two-column layout — Risk | Mitigation.
-
-**9. Coach's Corner**
-Two perspectives synthesized from the coaching frameworks:
-
-**Strategic Coach** (from `strategic-coach.md`):
-- Ecosystem positioning angle for this account
-- Enhancement framing recommendation
-- Ideal customer fit assessment
-- Guardrail reframe if applicable
-
-**Positioning Coach** (from `positioning-coach.md`):
-- Category framing recommendation
-- Competitive alternative analysis (what they'd do without you)
-- Language to mine from prior context
-- Heads on pillows test for this audience
-
-**10. Meeting Game Plan**
-Phase-by-phase timeline matched to the meeting duration. Time allocations are proportional:
-
-**30-minute meeting:**
-| Phase | Time | Focus |
-|-------|------|-------|
-| Open & Rapport | 0-3 min | Set the frame, confirm agenda |
-| Discovery / Pitch | 3-18 min | Core content (meeting-type-dependent) |
-| Proof & Stories | 18-23 min | Evidence that lands |
-| Next Steps | 23-28 min | Clear commitments |
-| Buffer | 28-30 min | Questions, soft close |
-
-**45-minute meeting:**
-| Phase | Time | Focus |
-|-------|------|-------|
-| Open & Rapport | 0-5 min | Set the frame, confirm agenda |
-| Discovery / Pitch | 5-25 min | Core content |
-| Proof & Stories | 25-33 min | Evidence that lands |
-| Discussion | 33-40 min | Questions, objection handling |
-| Next Steps | 40-45 min | Clear commitments |
-
-**60-minute meeting:**
-| Phase | Time | Focus |
-|-------|------|-------|
-| Open & Rapport | 0-5 min | Set the frame, confirm agenda |
-| Context Setting | 5-12 min | Status quo, their world |
-| Discovery / Pitch | 12-35 min | Core content |
-| Proof & Stories | 35-45 min | Evidence that lands |
-| Discussion | 45-53 min | Questions, objection handling |
-| Next Steps | 53-58 min | Clear commitments |
-| Buffer | 58-60 min | Soft close |
-
-**90-minute meeting:**
-| Phase | Time | Focus |
-|-------|------|-------|
-| Open & Rapport | 0-7 min | Set the frame, confirm agenda |
-| Context Setting | 7-18 min | Status quo, mutual discovery |
-| Discovery / Pitch | 18-50 min | Core content (deeper, more interactive) |
-| Proof & Stories | 50-62 min | Evidence + customer stories |
-| Deep Discussion | 62-75 min | Objections, technical deep-dives |
-| Action Planning | 75-85 min | Concrete next steps, timeline |
-| Close | 85-90 min | Summary, commitments |
-
-Each phase includes: what to say, what to listen for, and a transition line to the next phase.
-
-**11. Deal Intelligence**
-Key deal context at a glance:
-- **Budget**: Known budget or budget signals
-- **Champion**: Who is championing internally (or "not yet identified")
-- **Decision Maker**: Who ultimately signs
-- **Compelling Event**: Timeline driver, if any (quarter end, contract renewal, initiative launch)
-- **Competition**: Who else is in the deal
-- **Stage**: Current deal stage and how long they've been there
-- **Next Milestone**: What needs to happen next
-
-If no deal data exists (new prospect), present what's known and flag what to uncover in this meeting.
-
-**12. The Line**
-One memorable sentence that captures the strategic essence of this meeting. This is the thing you'd write on a sticky note and put on your monitor before the call. It should distill the entire battle plan into a single actionable insight.
-
-Examples:
-- "They believe the problem exists but don't believe anyone's solved it — that's your opening."
-- "The VP is bought in; the Director needs proof it won't break their workflow."
-- "This is a displacement deal — lead with what they lose by staying, not what they gain by switching."
-
-#### HTML Architecture
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Battle Plan: [Company] — [Meeting Type]</title>
-  <!-- Google Fonts (preconnect + stylesheet) -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=[fonts]&display=swap" rel="stylesheet">
-  <style>
-    /* === CSS Variables (from chosen preset) === */
-    :root { ... }
-
-    /* === Reset & Base === */
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    html { scroll-behavior: smooth; }
-    body {
-      background: var(--bg);
-      color: var(--text-primary);
-      font-family: var(--font-body);
-      line-height: 1.6;
-    }
-
-    /* === Layout === */
-    .battle-plan-container {
-      max-width: 900px;
-      margin: 0 auto;
-      padding: 2rem clamp(1rem, 4vw, 3rem);
-    }
-
-    /* === Sidebar Navigation (sticky) === */
-    .bp-nav {
-      position: fixed;
-      top: 50%;
-      right: clamp(0.5rem, 2vw, 2rem);
-      transform: translateY(-50%);
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-      z-index: 100;
-    }
-    .bp-nav a {
-      display: block;
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      background: var(--text-muted);
-      transition: all 0.3s ease;
-    }
-    .bp-nav a.active {
-      background: var(--brand-primary);
-      transform: scale(1.4);
-    }
-
-    /* === Section Styles === */
-    .bp-section {
-      margin-bottom: 2.5rem;
-      padding-bottom: 2rem;
-      border-bottom: 1px solid var(--border);
-    }
-
-    /* === Collapsible Sections (details/summary) === */
-    details.bp-section {
-      border-bottom: 1px solid var(--border);
-      margin-bottom: 2.5rem;
-      padding-bottom: 1rem;
-    }
-    details.bp-section summary {
-      cursor: pointer;
-      font-family: var(--font-display);
-      font-size: clamp(1.1rem, 2vw, 1.4rem);
-      font-weight: 600;
-      color: var(--text-primary);
-      padding: 0.75rem 0;
-      list-style: none;
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-    details.bp-section summary::before {
-      content: "\25B6";
-      font-size: 0.7em;
-      color: var(--brand-primary);
-      transition: transform 0.2s ease;
-    }
-    details.bp-section[open] summary::before {
-      transform: rotate(90deg);
-    }
-
-    /* === Cards === */
-    .card {
-      background: var(--bg-card);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-lg);
-      padding: clamp(1rem, 2vw, 1.5rem);
-    }
-    .card:hover {
-      background: var(--bg-card-hover);
-    }
-
-    /* === Stakeholder Cards === */
-    .stakeholder-card {
-      display: flex;
-      gap: 1rem;
-      align-items: flex-start;
-    }
-    .stakeholder-avatar {
-      width: 48px;
-      height: 48px;
-      border-radius: 50%;
-      background: var(--brand-primary);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: white;
-      font-weight: 700;
-      flex-shrink: 0;
-    }
-
-    /* === Buying Role Badge === */
-    .role-badge {
-      display: inline-block;
-      padding: 0.2rem 0.6rem;
-      border-radius: var(--radius-pill);
-      font-size: 0.7rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
-    .role-badge.champion { background: var(--success); color: white; }
-    .role-badge.budget-owner { background: var(--brand-primary); color: white; }
-    .role-badge.evaluator { background: var(--secondary); color: white; }
-    .role-badge.gatekeeper { background: var(--warning); color: #1a1a1a; }
-
-    /* === Belief Stack === */
-    .belief-item {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      padding: 0.75rem 1rem;
-      border-radius: var(--radius);
-      margin-bottom: 0.5rem;
-    }
-    .belief-status {
-      width: 12px;
-      height: 12px;
-      border-radius: 50%;
-      flex-shrink: 0;
-    }
-    .belief-status.proven { background: var(--success); }
-    .belief-status.mostly-proven { background: var(--warning); }
-    .belief-status.needs-proof { background: var(--error); }
-
-    /* === Talk Track Cards === */
-    .talk-track {
-      background: var(--bg-elevated);
-      border-left: 3px solid var(--brand-primary);
-      padding: 1rem 1.25rem;
-      border-radius: 0 var(--radius) var(--radius) 0;
-      margin-bottom: 1rem;
-    }
-    .talk-track .label {
-      font-size: 0.7rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: var(--brand-primary);
-      margin-bottom: 0.25rem;
-    }
-    .coaching-note {
-      font-size: 0.8rem;
-      color: var(--text-muted);
-      font-style: italic;
-      margin-top: 0.5rem;
-    }
-
-    /* === Risk/Mitigation Grid === */
-    .risk-grid {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: clamp(0.75rem, 1.5vw, 1.25rem);
-    }
-    .risk-item { border-left: 3px solid var(--error); }
-    .mitigation-item { border-left: 3px solid var(--success); }
-
-    /* === Game Plan Timeline === */
-    .game-plan-phase {
-      display: grid;
-      grid-template-columns: 100px 1fr;
-      gap: 1rem;
-      padding: 1rem 0;
-      border-bottom: 1px solid var(--border);
-    }
-    .phase-time {
-      font-family: var(--font-mono);
-      font-size: 0.85rem;
-      color: var(--brand-primary);
-      font-weight: 600;
-    }
-
-    /* === The Line (featured) === */
-    .the-line {
-      text-align: center;
-      padding: 2rem;
-      border: 2px solid var(--brand-primary);
-      border-radius: var(--radius-lg);
-      margin-top: 2rem;
-    }
-    .the-line blockquote {
-      font-family: var(--font-display);
-      font-size: clamp(1.2rem, 2.5vw, 1.6rem);
-      font-weight: 500;
-      font-style: italic;
-      color: var(--text-primary);
-    }
-
-    /* === Meeting Type Badge === */
-    .meeting-badge {
-      display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: var(--radius-pill);
-      background: var(--brand-primary);
-      color: white;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
-    .duration-badge {
-      display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: var(--radius-pill);
-      background: var(--bg-elevated);
-      border: 1px solid var(--border-strong);
-      color: var(--text-secondary);
-      font-size: 0.75rem;
-      font-weight: 600;
-    }
-
-    /* === Grid Utilities === */
-    .grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: clamp(0.75rem, 1.5vw, 1.25rem); }
-    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: clamp(0.75rem, 1.5vw, 1.25rem); }
-
-    /* === Typography === */
-    .section-title {
-      font-family: var(--font-display);
-      font-size: clamp(1.1rem, 2vw, 1.4rem);
-      font-weight: 600;
-      margin-bottom: 1rem;
-    }
-    .body-text { font-size: clamp(0.85rem, 1.2vw, 1rem); }
-    .text-secondary { color: var(--text-secondary); }
-    .text-muted { color: var(--text-muted); }
-
-    /* === Deal Intel Cards === */
-    .deal-intel-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: clamp(0.75rem, 1.5vw, 1.25rem);
-    }
-    .deal-intel-card {
-      text-align: center;
-      padding: 1rem;
-    }
-    .deal-intel-card .label {
-      font-size: 0.7rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: var(--text-muted);
-      margin-bottom: 0.25rem;
-    }
-    .deal-intel-card .value {
-      font-family: var(--font-display);
-      font-size: 1.1rem;
-      font-weight: 600;
-    }
-
-    /* === Print Styles === */
-    @media print {
-      .bp-nav { display: none; }
-      .battle-plan-container { max-width: 100%; padding: 1rem; }
-      details.bp-section { open; }
-      details.bp-section[open] { break-inside: avoid; }
-      .card { break-inside: avoid; }
-      body { color: #111; background: white; }
-      .meeting-badge { border: 1px solid #111; background: transparent; color: #111; }
-    }
-
-    /* === Responsive === */
-    @media (max-width: 768px) {
-      .grid-2, .grid-3 { grid-template-columns: 1fr; }
-      .risk-grid { grid-template-columns: 1fr; }
-      .game-plan-phase { grid-template-columns: 80px 1fr; }
-      .bp-nav { display: none; }
-    }
-
-    /* === prefers-reduced-motion === */
-    @media (prefers-reduced-motion: reduce) {
-      * { transition: none !important; animation: none !important; }
-    }
-  </style>
-</head>
-<body>
-
-  <!-- Sidebar Navigation Dots -->
-  <nav class="bp-nav" id="bp-nav">
-    <!-- Generated by JS: one dot per section -->
-  </nav>
-
-  <!-- Main Battle Plan -->
-  <main class="battle-plan-container">
-
-    <!-- 1. Header -->
-    <header class="bp-section">
-      <span class="meeting-badge">[Meeting Type] Battle Plan</span>
-      <span class="duration-badge">[Duration] min</span>
-      <h1>[Company Name] — Meeting Prep</h1>
-      <p class="text-secondary">[Date] · [Attendees summary]</p>
-    </header>
-
-    <!-- 2. TL;DR -->
-    <section class="bp-section" id="tldr">
-      <h2 class="section-title">TL;DR</h2>
-      <p class="body-text">[2-3 sentence opportunity summary]</p>
-    </section>
-
-    <!-- 3. Stakeholder Map -->
-    <details class="bp-section" open id="stakeholder-map">
-      <summary>Stakeholder Map</summary>
-      <div class="grid-2">
-        <!-- Stakeholder cards with role badges -->
-      </div>
-    </details>
-
-    <!-- 4. Their Pain -->
-    <details class="bp-section" open id="their-pain">
-      <summary>Their Pain</summary>
-      <!-- Pain points by stakeholder or theme -->
-    </details>
-
-    <!-- 5. What They Need to Believe -->
-    <details class="bp-section" open id="belief-stack">
-      <summary>What They Need to Believe</summary>
-      <!-- Belief items with status indicators -->
-    </details>
-
-    <!-- 6. Positioned Sales Pitch -->
-    <details class="bp-section" open id="sales-pitch">
-      <summary>Positioned Sales Pitch</summary>
-      <!-- 5-step talk track cards -->
-    </details>
-
-    <!-- 7. Discovery Questions -->
-    <details class="bp-section" open id="discovery-questions">
-      <summary>Discovery Questions</summary>
-      <!-- Questions segmented by stakeholder or category -->
-    </details>
-
-    <!-- 8. Landmines & Watch-Outs -->
-    <details class="bp-section" open id="landmines">
-      <summary>Landmines & Watch-Outs</summary>
-      <div class="risk-grid">
-        <!-- Risk/mitigation pairs -->
-      </div>
-    </details>
-
-    <!-- 9. Coach's Corner -->
-    <details class="bp-section" open id="coachs-corner">
-      <summary>Coach's Corner</summary>
-      <div class="grid-2">
-        <!-- Strategic coach card + Positioning coach card -->
-      </div>
-    </details>
-
-    <!-- 10. Meeting Game Plan -->
-    <details class="bp-section" open id="game-plan">
-      <summary>Meeting Game Plan</summary>
-      <!-- Phase timeline matched to duration -->
-    </details>
-
-    <!-- 11. Deal Intelligence -->
-    <details class="bp-section" open id="deal-intel">
-      <summary>Deal Intelligence</summary>
-      <div class="deal-intel-grid">
-        <!-- Budget, Champion, Decision Maker, Compelling Event cards -->
-      </div>
-    </details>
-
-    <!-- 12. The Line -->
-    <section class="bp-section" id="the-line">
-      <div class="the-line">
-        <blockquote>"[One memorable sentence]"</blockquote>
-      </div>
-    </section>
-
-  </main>
-
-  <script>
-    // Generate nav dots from sections
-    // Intersection Observer for active section tracking
-    // Smooth scroll on nav dot click
-    // Open all details on print (window.onbeforeprint)
-  </script>
-
-</body>
-</html>
-```
-
-**Self-contained:** Inline CSS, zero external dependencies (except Google Fonts). No JavaScript frameworks.
-
-#### Content Density Guidelines
-
-Battle plans are reference documents — they should be thorough but scannable:
-
-| Section | Content Limit |
-|---------|--------------|
-| TL;DR | 2-3 sentences max |
-| Stakeholder Map | 4-6 stakeholder cards max |
-| Their Pain | 4-6 pain points max |
-| What They Need to Believe | 5-6 beliefs max |
-| Positioned Sales Pitch | 5 steps, each with 2-3 sentence talk track |
-| Discovery Questions | 8-12 questions max |
-| Landmines & Watch-Outs | 4-6 risk/mitigation pairs |
-| Coach's Corner | 2 perspectives, 3-4 bullets each |
-| Meeting Game Plan | 5-7 phases matching duration |
-| Deal Intelligence | 6-8 data fields |
-| The Line | 1 sentence |
-
-If a section would exceed its limit, prioritize by relevance to the meeting type and trim the rest.
+Keep the battle plan thorough but scannable: TL;DR 2-3 sentences, Stakeholder Map 4-6 cards, Pain 4-6 points, Beliefs 5-6 max, Pitch 5 steps with 2-3 sentence tracks, Questions 8-12 max, Landmines 4-6 pairs, Coach's Corner 3-4 bullets per perspective, Game Plan 5-7 phases, Deal Intel 6-8 fields, The Line 1 sentence. Prioritize by meeting type relevance when trimming.
 
 ### Step 5: Delivery
 
-After generating the HTML file:
+Open the battle plan in the default browser. Present: file path, style, duration, sections included, and navigation tips (scroll, sidebar dots, collapsible sections, Cmd+P for PDF).
 
-1. **Open the battle plan** in the default browser
-2. **Present a summary:**
-
-```
-BATTLE PLAN READY
-==================
-
-Folder: .octave-meeting-prep/<name>-<date>/
-File:   .octave-meeting-prep/<name>-<date>/<name>.html
-Style:  [Preset name or "Custom Brand"]
-Duration: [30 / 45 / 60 / 90] min game plan
-Sections: [List of included sections]
-
-Navigation:
-- Scroll naturally to read through sections
-- Click nav dots on the right edge to jump to sections
-- Click section headers to collapse/expand
-- Print-friendly: Cmd+P / Ctrl+P for clean PDF output
-
----
-
-Want me to:
-1. Adjust or expand a section
-2. Add/remove stakeholders
-3. Go deeper on any topic (beliefs, talk tracks, questions)
-4. Change the style
-5. Regenerate for a different meeting duration
-6. Export as PDF (print dialog)
-7. Generate a brief for this account (/octave:brief)
-8. Build a presentation from this (/octave:deck)
-9. Done
-```
-
-## MCP Tools Used
-
-### Research & Enrichment
-- `enrich_company` — Full company intelligence profile
-- `enrich_person` — Full person intelligence report
-- `find_person` — Find contacts at a company by title/role
-- `find_company` — Find companies matching criteria
-- `qualify_company` — ICP fit scoring for a company
-- `qualify_person` — ICP fit scoring for a person
-
-### Library — Fetching Entities
-- `list_all_entities` — Quick scan of all entities of a type (minimal fields, no pagination)
-- `list_entities` — Fetch entities with full data and pagination (proof points, references, etc.)
-- `get_entity` — Deep dive on one specific entity
-- `get_playbook` — Retrieve a playbook with full content and value props
-- `list_value_props` — Value propositions for a specific playbook
-
-### Library — Searching
-- `search_knowledge_base` — Semantic search across library entities and resources
-- `list_resources` — Browse uploaded docs, URLs, and Google Drive files
-- `search_resources` — Semantic search across uploaded resources
-
-### Intelligence & Signals
-- `list_findings` — Recent conversation findings and insights
-- `list_events` — Deal events (stage changes, meetings, outcomes)
-- `get_event_detail` — Full details for a specific event
-
-### Content Generation
-- `generate_call_prep` — Synthesized prep brief (useful as a starting point)
-- `generate_content` — Generate positioning or messaging content
+Offer follow-up actions: adjust/expand a section, add/remove stakeholders, go deeper on any topic, change style, regenerate for different duration, export PDF, generate a brief (`/octave:brief`), or build a presentation (`/octave:deck`).
 
 ## Error Handling
 
-**No user context provided:**
-> No prior context provided. I'll build the battle plan from Octave intelligence and coaching frameworks.
->
-> The prep will be strong on strategy and positioning. After the meeting, run this again with your notes for a grounded follow-up prep.
-
-**Coaching reference files not found:**
-> Coaching reference files not found in `references/`. Using general sales coaching best practices.
->
-> To customize coaching frameworks, add `strategic-coach.md` and `positioning-coach.md` to the `skills/meeting-prep/references/` directory.
-
-**Octave Connection Failed:**
-> Could not connect to your Octave workspace.
->
-> I'll build the battle plan from your provided context and coaching frameworks. The result will focus on talk tracks, discovery questions, and game plan without enrichment data.
->
-> To reconnect: check your MCP configuration or run `/octave:workspace status`
-
-**Company Not Found:**
-> I couldn't find detailed intelligence for [domain].
->
-> Options:
-> 1. Check the domain spelling and try again
-> 2. Try a different domain or company name
-> 3. Provide company details manually and I'll build the battle plan
-
-**No Findings Data:**
-> No conversation signals found for [company/person] in the last 90 days.
->
-> Skipping the Prior Intelligence section. The battle plan will focus on enrichment data, coaching frameworks, and your provided context.
-
-**Attendees Not Specified:**
-> No specific attendees provided. I'll build a general stakeholder map from Octave contacts and apply coaching frameworks broadly.
->
-> Tip: Adding attendee names and roles before the meeting makes the belief stack and talk tracks much sharper.
-
-**No Matching Playbook:**
-> No playbook matches this audience profile directly.
->
-> I'll use general value props and positioning from the knowledge base, combined with coaching frameworks. Consider creating a playbook for this segment: `/octave:library create playbook`
-
-## Related Skills
-
-- `/octave:brief` — Internal account dossier (reference doc without coaching frameworks)
-- `/octave:research` — Deep-dive research on a company or person
-- `/octave:deck` — Full slide presentation for the audience
-- `/octave:one-pager` — Customer-facing leave-behind document
-- `/octave:battlecard` — Competitive intelligence and displacement strategy
-- `/octave:pipeline` — Deal-level coaching and pipeline strategy
-- `/octave:abm` — Account-based planning with stakeholder mapping
+| Scenario | Response |
+|----------|----------|
+| No user context | Build from Octave intel + coaching frameworks; suggest re-running with notes after meeting |
+| Coaching files not found | Fall back to general sales coaching; suggest adding custom files to `references/` |
+| Octave connection failed | Build from user context + coaching frameworks; suggest checking MCP config |
+| Company not found | Offer: check domain, try different domain, provide details manually |
+| No findings data | Skip Prior Intelligence section; build from enrichment + coaching + user context |
+| Attendees unknown | Build general stakeholder map from Octave contacts |
+| No matching playbook | Use general value props from knowledge base + coaching frameworks |

--- a/skills/meeting-prep/references/battle-plan-template.html
+++ b/skills/meeting-prep/references/battle-plan-template.html
@@ -1,0 +1,430 @@
+# Battle Plan HTML Template
+
+Self-contained HTML architecture for the meeting battle plan. Use the chosen style preset's CSS variables (see `/octave:deck` STYLE_PRESETS.md for full preset definitions).
+
+## Output Directory
+
+```
+.octave-meeting-prep/
+└── <kebab-case-name>-<YYYY-MM-DD>/
+    └── <name>.html
+```
+
+Example: `/octave:meeting-prep acme.com --type discovery` -> `.octave-meeting-prep/acme-discovery-2026-02-27/acme-discovery.html`
+
+The `.octave-meeting-prep/` directory should be in `.gitignore`.
+
+## HTML Scaffold
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Battle Plan: [Company] — [Meeting Type]</title>
+  <!-- Google Fonts (preconnect + stylesheet) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=[fonts]&display=swap" rel="stylesheet">
+  <style>
+    /* === CSS Variables (from chosen preset) === */
+    :root { ... }
+
+    /* === Reset & Base === */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body {
+      background: var(--bg);
+      color: var(--text-primary);
+      font-family: var(--font-body);
+      line-height: 1.6;
+    }
+
+    /* === Layout === */
+    .battle-plan-container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem clamp(1rem, 4vw, 3rem);
+    }
+
+    /* === Sidebar Navigation (sticky) === */
+    .bp-nav {
+      position: fixed;
+      top: 50%;
+      right: clamp(0.5rem, 2vw, 2rem);
+      transform: translateY(-50%);
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      z-index: 100;
+    }
+    .bp-nav a {
+      display: block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--text-muted);
+      transition: all 0.3s ease;
+    }
+    .bp-nav a.active {
+      background: var(--brand-primary);
+      transform: scale(1.4);
+    }
+
+    /* === Section Styles === */
+    .bp-section {
+      margin-bottom: 2.5rem;
+      padding-bottom: 2rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    /* === Collapsible Sections (details/summary) === */
+    details.bp-section {
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 2.5rem;
+      padding-bottom: 1rem;
+    }
+    details.bp-section summary {
+      cursor: pointer;
+      font-family: var(--font-display);
+      font-size: clamp(1.1rem, 2vw, 1.4rem);
+      font-weight: 600;
+      color: var(--text-primary);
+      padding: 0.75rem 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    details.bp-section summary::before {
+      content: "\25B6";
+      font-size: 0.7em;
+      color: var(--brand-primary);
+      transition: transform 0.2s ease;
+    }
+    details.bp-section[open] summary::before {
+      transform: rotate(90deg);
+    }
+
+    /* === Cards === */
+    .card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: clamp(1rem, 2vw, 1.5rem);
+    }
+    .card:hover {
+      background: var(--bg-card-hover);
+    }
+
+    /* === Stakeholder Cards === */
+    .stakeholder-card {
+      display: flex;
+      gap: 1rem;
+      align-items: flex-start;
+    }
+    .stakeholder-avatar {
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background: var(--brand-primary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+
+    /* === Buying Role Badge === */
+    .role-badge {
+      display: inline-block;
+      padding: 0.2rem 0.6rem;
+      border-radius: var(--radius-pill);
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .role-badge.champion { background: var(--success); color: white; }
+    .role-badge.budget-owner { background: var(--brand-primary); color: white; }
+    .role-badge.evaluator { background: var(--secondary); color: white; }
+    .role-badge.gatekeeper { background: var(--warning); color: #1a1a1a; }
+
+    /* === Belief Stack === */
+    .belief-item {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.75rem 1rem;
+      border-radius: var(--radius);
+      margin-bottom: 0.5rem;
+    }
+    .belief-status {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .belief-status.proven { background: var(--success); }
+    .belief-status.mostly-proven { background: var(--warning); }
+    .belief-status.needs-proof { background: var(--error); }
+
+    /* === Talk Track Cards === */
+    .talk-track {
+      background: var(--bg-elevated);
+      border-left: 3px solid var(--brand-primary);
+      padding: 1rem 1.25rem;
+      border-radius: 0 var(--radius) var(--radius) 0;
+      margin-bottom: 1rem;
+    }
+    .talk-track .label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--brand-primary);
+      margin-bottom: 0.25rem;
+    }
+    .coaching-note {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      font-style: italic;
+      margin-top: 0.5rem;
+    }
+
+    /* === Risk/Mitigation Grid === */
+    .risk-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: clamp(0.75rem, 1.5vw, 1.25rem);
+    }
+    .risk-item { border-left: 3px solid var(--error); }
+    .mitigation-item { border-left: 3px solid var(--success); }
+
+    /* === Game Plan Timeline === */
+    .game-plan-phase {
+      display: grid;
+      grid-template-columns: 100px 1fr;
+      gap: 1rem;
+      padding: 1rem 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .phase-time {
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      color: var(--brand-primary);
+      font-weight: 600;
+    }
+
+    /* === The Line (featured) === */
+    .the-line {
+      text-align: center;
+      padding: 2rem;
+      border: 2px solid var(--brand-primary);
+      border-radius: var(--radius-lg);
+      margin-top: 2rem;
+    }
+    .the-line blockquote {
+      font-family: var(--font-display);
+      font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+      font-weight: 500;
+      font-style: italic;
+      color: var(--text-primary);
+    }
+
+    /* === Meeting Type Badge === */
+    .meeting-badge {
+      display: inline-block;
+      padding: 0.25rem 0.75rem;
+      border-radius: var(--radius-pill);
+      background: var(--brand-primary);
+      color: white;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .duration-badge {
+      display: inline-block;
+      padding: 0.25rem 0.75rem;
+      border-radius: var(--radius-pill);
+      background: var(--bg-elevated);
+      border: 1px solid var(--border-strong);
+      color: var(--text-secondary);
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    /* === Grid Utilities === */
+    .grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: clamp(0.75rem, 1.5vw, 1.25rem); }
+    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: clamp(0.75rem, 1.5vw, 1.25rem); }
+
+    /* === Typography === */
+    .section-title {
+      font-family: var(--font-display);
+      font-size: clamp(1.1rem, 2vw, 1.4rem);
+      font-weight: 600;
+      margin-bottom: 1rem;
+    }
+    .body-text { font-size: clamp(0.85rem, 1.2vw, 1rem); }
+    .text-secondary { color: var(--text-secondary); }
+    .text-muted { color: var(--text-muted); }
+
+    /* === Deal Intel Cards === */
+    .deal-intel-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: clamp(0.75rem, 1.5vw, 1.25rem);
+    }
+    .deal-intel-card {
+      text-align: center;
+      padding: 1rem;
+    }
+    .deal-intel-card .label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      margin-bottom: 0.25rem;
+    }
+    .deal-intel-card .value {
+      font-family: var(--font-display);
+      font-size: 1.1rem;
+      font-weight: 600;
+    }
+
+    /* === Print Styles === */
+    @media print {
+      .bp-nav { display: none; }
+      .battle-plan-container { max-width: 100%; padding: 1rem; }
+      details.bp-section { open; }
+      details.bp-section[open] { break-inside: avoid; }
+      .card { break-inside: avoid; }
+      body { color: #111; background: white; }
+      .meeting-badge { border: 1px solid #111; background: transparent; color: #111; }
+    }
+
+    /* === Responsive === */
+    @media (max-width: 768px) {
+      .grid-2, .grid-3 { grid-template-columns: 1fr; }
+      .risk-grid { grid-template-columns: 1fr; }
+      .game-plan-phase { grid-template-columns: 80px 1fr; }
+      .bp-nav { display: none; }
+    }
+
+    /* === prefers-reduced-motion === */
+    @media (prefers-reduced-motion: reduce) {
+      * { transition: none !important; animation: none !important; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Sidebar Navigation Dots -->
+  <nav class="bp-nav" id="bp-nav">
+    <!-- Generated by JS: one dot per section -->
+  </nav>
+
+  <!-- Main Battle Plan -->
+  <main class="battle-plan-container">
+
+    <!-- 1. Header -->
+    <header class="bp-section">
+      <span class="meeting-badge">[Meeting Type] Battle Plan</span>
+      <span class="duration-badge">[Duration] min</span>
+      <h1>[Company Name] — Meeting Prep</h1>
+      <p class="text-secondary">[Date] · [Attendees summary]</p>
+    </header>
+
+    <!-- 2. TL;DR -->
+    <section class="bp-section" id="tldr">
+      <h2 class="section-title">TL;DR</h2>
+      <p class="body-text">[2-3 sentence opportunity summary]</p>
+    </section>
+
+    <!-- 3. Stakeholder Map -->
+    <details class="bp-section" open id="stakeholder-map">
+      <summary>Stakeholder Map</summary>
+      <div class="grid-2">
+        <!-- Stakeholder cards with role badges -->
+      </div>
+    </details>
+
+    <!-- 4. Their Pain -->
+    <details class="bp-section" open id="their-pain">
+      <summary>Their Pain</summary>
+      <!-- Pain points by stakeholder or theme -->
+    </details>
+
+    <!-- 5. What They Need to Believe -->
+    <details class="bp-section" open id="belief-stack">
+      <summary>What They Need to Believe</summary>
+      <!-- Belief items with status indicators -->
+    </details>
+
+    <!-- 6. Positioned Sales Pitch -->
+    <details class="bp-section" open id="sales-pitch">
+      <summary>Positioned Sales Pitch</summary>
+      <!-- 5-step talk track cards -->
+    </details>
+
+    <!-- 7. Discovery Questions -->
+    <details class="bp-section" open id="discovery-questions">
+      <summary>Discovery Questions</summary>
+      <!-- Questions segmented by stakeholder or category -->
+    </details>
+
+    <!-- 8. Landmines & Watch-Outs -->
+    <details class="bp-section" open id="landmines">
+      <summary>Landmines & Watch-Outs</summary>
+      <div class="risk-grid">
+        <!-- Risk/mitigation pairs -->
+      </div>
+    </details>
+
+    <!-- 9. Coach's Corner -->
+    <details class="bp-section" open id="coachs-corner">
+      <summary>Coach's Corner</summary>
+      <div class="grid-2">
+        <!-- Strategic coach card + Positioning coach card -->
+      </div>
+    </details>
+
+    <!-- 10. Meeting Game Plan -->
+    <details class="bp-section" open id="game-plan">
+      <summary>Meeting Game Plan</summary>
+      <!-- Phase timeline matched to duration -->
+    </details>
+
+    <!-- 11. Deal Intelligence -->
+    <details class="bp-section" open id="deal-intel">
+      <summary>Deal Intelligence</summary>
+      <div class="deal-intel-grid">
+        <!-- Budget, Champion, Decision Maker, Compelling Event cards -->
+      </div>
+    </details>
+
+    <!-- 12. The Line -->
+    <section class="bp-section" id="the-line">
+      <div class="the-line">
+        <blockquote>"[One memorable sentence]"</blockquote>
+      </div>
+    </section>
+
+  </main>
+
+  <script>
+    // Generate nav dots from sections
+    // Intersection Observer for active section tracking
+    // Smooth scroll on nav dot click
+    // Open all details on print (window.onbeforeprint)
+  </script>
+
+</body>
+</html>
+```
+
+**Self-contained:** Inline CSS, zero external dependencies (except Google Fonts). No JavaScript frameworks.

--- a/skills/meeting-prep/references/game-plan-timing.md
+++ b/skills/meeting-prep/references/game-plan-timing.md
@@ -1,0 +1,47 @@
+# Meeting Game Plan — Duration Timing Reference
+
+Phase-by-phase time allocations proportional to meeting duration. Each phase includes: what to say, what to listen for, and a transition line to the next phase.
+
+## 30-Minute Meeting
+
+| Phase | Time | Focus |
+|-------|------|-------|
+| Open & Rapport | 0-3 min | Set the frame, confirm agenda |
+| Discovery / Pitch | 3-18 min | Core content (meeting-type-dependent) |
+| Proof & Stories | 18-23 min | Evidence that lands |
+| Next Steps | 23-28 min | Clear commitments |
+| Buffer | 28-30 min | Questions, soft close |
+
+## 45-Minute Meeting
+
+| Phase | Time | Focus |
+|-------|------|-------|
+| Open & Rapport | 0-5 min | Set the frame, confirm agenda |
+| Discovery / Pitch | 5-25 min | Core content |
+| Proof & Stories | 25-33 min | Evidence that lands |
+| Discussion | 33-40 min | Questions, objection handling |
+| Next Steps | 40-45 min | Clear commitments |
+
+## 60-Minute Meeting
+
+| Phase | Time | Focus |
+|-------|------|-------|
+| Open & Rapport | 0-5 min | Set the frame, confirm agenda |
+| Context Setting | 5-12 min | Status quo, their world |
+| Discovery / Pitch | 12-35 min | Core content |
+| Proof & Stories | 35-45 min | Evidence that lands |
+| Discussion | 45-53 min | Questions, objection handling |
+| Next Steps | 53-58 min | Clear commitments |
+| Buffer | 58-60 min | Soft close |
+
+## 90-Minute Meeting
+
+| Phase | Time | Focus |
+|-------|------|-------|
+| Open & Rapport | 0-7 min | Set the frame, confirm agenda |
+| Context Setting | 7-18 min | Status quo, mutual discovery |
+| Discovery / Pitch | 18-50 min | Core content (deeper, more interactive) |
+| Proof & Stories | 50-62 min | Evidence + customer stories |
+| Deep Discussion | 62-75 min | Objections, technical deep-dives |
+| Action Planning | 75-85 min | Concrete next steps, timeline |
+| Close | 85-90 min | Summary, commitments |

--- a/skills/meeting-prep/references/mcp-tool-reference.md
+++ b/skills/meeting-prep/references/mcp-tool-reference.md
@@ -1,0 +1,101 @@
+# MCP Tool Reference for Meeting Prep
+
+## List vs Search — When to Use Which
+
+| Tool | Purpose | Use when... |
+|------|---------|-------------|
+| `list_all_entities({ entityType })` | Fetch all entities of a type (minimal fields) | You want a quick inventory — "show me all our competitors" |
+| `list_entities({ entityType })` | Fetch entities with full data (paginated) | You need the actual content — "get full proof point details" |
+| `get_entity({ oId })` | Deep dive on one specific entity | You found something relevant and need the complete picture |
+| `search_knowledge_base({ query })` | Semantic search across library + resources | You have a concept or question — "how do we position for healthcare?" |
+| `list_resources()` / `search_resources({ query })` | Uploaded docs, URLs, Google Drive files | You need reference material, uploaded assets, or source docs |
+
+**Rule of thumb:** Use `list_*` when you know *what type* of thing you want. Use `search_*` when you know *what topic* you're looking for.
+
+## Findings and Events — Always Attempt, Gracefully Skip
+
+ALWAYS try to pull findings and events if you have a company domain or contact emails. Use a 90-day window. If data exists, it populates the "Prior Intelligence" section. If not, silently omit — no error message.
+
+- `list_findings({ query: "<company or contact>", startDate: "<90 days ago>" })` — surfaces what was actually said in calls: objections raised, features requested, pain points confirmed, competitor mentions
+- `list_events({ filters: { accounts: ["<account_oId>"] } })` — deal stage changes, meetings held, emails sent
+- `get_event_detail({ eventOId })` — deep dive on specific past interactions
+
+---
+
+## Person-Targeted Prep Tools
+
+Start with person and company enrichment, then pull positioning context:
+
+| What you need | Tool | When to use |
+|---------------|------|-------------|
+| Person deep-dive | `enrich_person({ person: { email, firstName, lastName, companyDomain } })` | Always for person-targeted preps — gives background, role, priorities |
+| Company profile | `enrich_company({ companyDomain })` | Always — gives industry, size, tech stack, signals |
+| ICP fit (person) | `qualify_person({ person: { ... } })` | When you need persona match and fit assessment |
+| ICP fit (company) | `qualify_company({ companyDomain })` | When you need segment match and ICP scoring |
+| Additional contacts | `find_person({ searchMode: "people", companyDomain, fuzzyTitles })` | When you want to map the broader buying committee |
+| Matching playbook | `get_playbook({ oId, includeValueProps: true })` | After identifying relevant playbook — full strategy + value props |
+| Playbook search | `search_knowledge_base({ query: "<industry> <persona>", entityTypes: ["playbook"] })` | When you need the best-fit playbook by concept |
+| Proof points | `list_entities({ entityType: "proof_point" })` | Fetch all proof points with full data — metrics, quotes, logos |
+| References | `list_entities({ entityType: "reference" })` | Customer references with full details |
+| Competitive context | `search_knowledge_base({ query: "<signals>", entityTypes: ["competitor"] })` | When competitor is mentioned or likely in the deal |
+| Recent intel | `list_findings({ query: "<company or person>", startDate: "<90 days ago>" })` | Conversation-based insights from past interactions |
+| Deal history | `list_events({ filters: { accounts: ["<account_oId>"] } })` | Timeline of deal events |
+| Synthesized prep | `generate_call_prep({ companyDomain })` | Quick comprehensive brief to use as a starting point |
+
+---
+
+## Company-Targeted Prep Tools
+
+Start with company enrichment and contact discovery:
+
+| What you need | Tool | When to use |
+|---------------|------|-------------|
+| Company profile | `enrich_company({ companyDomain })` | Always — gives industry, size, tech stack, funding, signals |
+| ICP fit scoring | `qualify_company({ companyDomain })` | Always — segment match, fit score, fit reasons |
+| Key contacts | `find_person({ searchMode: "people", companyDomain, fuzzyTitles })` | Find stakeholders to populate the Stakeholder Map |
+| Enrich contacts | `enrich_person({ person: { ... } })` | Deep dive on each key contact found |
+| All playbooks | `list_all_entities({ entityType: "playbook" })` | Quick scan to find the right strategic approach |
+| Playbook details | `get_playbook({ oId, includeValueProps: true })` | Full content + value props for the matching playbook |
+| Value props | `list_value_props({ playbookOId })` | Fetch value props for the recommended playbook |
+| All competitors | `list_all_entities({ entityType: "competitor" })` | Quick scan of competitive landscape |
+| Competitor details | `get_entity({ oId })` | Deep dive on a specific relevant competitor |
+| Proof points | `list_entities({ entityType: "proof_point" })` | Full proof points for the evidence section |
+| References | `list_entities({ entityType: "reference" })` | Customer references for social proof |
+| Topic search | `search_knowledge_base({ query: "<industry> <use case>", entityTypes: ["proof_point", "reference"] })` | Find proof points relevant to their specific situation |
+| Recent intel | `list_findings({ query: "<company>", startDate: "<90 days ago>" })` | Conversation signals from calls and meetings |
+| Deal events | `list_events({ filters: { accounts: ["<account_oId>"] } })` | Full deal history and timeline |
+| Event details | `get_event_detail({ eventOId })` | Deep dive on specific past interactions |
+| Uploaded resources | `search_resources({ query: "<company or industry>" })` | Relevant uploaded docs and assets |
+
+---
+
+## Full MCP Tool Summary
+
+### Research & Enrichment
+- `enrich_company` — Full company intelligence profile
+- `enrich_person` — Full person intelligence report
+- `find_person` — Find contacts at a company by title/role
+- `find_company` — Find companies matching criteria
+- `qualify_company` — ICP fit scoring for a company
+- `qualify_person` — ICP fit scoring for a person
+
+### Library — Fetching Entities
+- `list_all_entities` — Quick scan of all entities of a type (minimal fields, no pagination)
+- `list_entities` — Fetch entities with full data and pagination (proof points, references, etc.)
+- `get_entity` — Deep dive on one specific entity
+- `get_playbook` — Retrieve a playbook with full content and value props
+- `list_value_props` — Value propositions for a specific playbook
+
+### Library — Searching
+- `search_knowledge_base` — Semantic search across library entities and resources
+- `list_resources` — Browse uploaded docs, URLs, and Google Drive files
+- `search_resources` — Semantic search across uploaded resources
+
+### Intelligence & Signals
+- `list_findings` — Recent conversation findings and insights
+- `list_events` — Deal events (stage changes, meetings, outcomes)
+- `get_event_detail` — Full details for a specific event
+
+### Content Generation
+- `generate_call_prep` — Synthesized prep brief (useful as a starting point)
+- `generate_content` — Generate positioning or messaging content

--- a/skills/positioning/SKILL.md
+++ b/skills/positioning/SKILL.md
@@ -1,18 +1,11 @@
 ---
 name: positioning
-description: Generate a complete Messaging & Positioning system as a stunning visual HTML document — message framework, positioning anchors, strategy table, persona-based messaging, awareness funnel, use case canvases, lifecycle mapping, and homepage messaging. Use when user says "positioning system", "positioning exercise", "message framework", "positioning anchors", "positioning document", "visual messaging framework", or asks for a comprehensive positioning deliverable.
+description: "Generate a complete Messaging & Positioning system as a stunning visual HTML document — message framework, positioning anchors, strategy table, persona-based messaging, awareness funnel, use case canvases, lifecycle mapping, and homepage messaging. Use when user says 'positioning system', 'positioning exercise', 'message framework', 'positioning anchors', 'positioning document', 'visual messaging framework', or asks for a comprehensive positioning deliverable."
 ---
 
 # /octave:positioning - Visual Messaging & Positioning System
 
-Generate a complete, visual Messaging & Positioning system rendered as a single stunning HTML document. Eight interconnected frameworks — from the foundational Message Framework through Positioning Anchors, Strategy Table, Persona Messaging, Awareness Funnel, Use Case Canvas, Lifecycle Mapping, and Homepage Messaging — all pulled from your Octave library and grounded in real conversation evidence.
-
-Unlike `/octave:messaging` which outputs text-based frameworks, this skill renders the full positioning system as a polished, scrollable HTML document with visual grids, color-coded persona columns, funnel diagrams, timelines, and split-view canvases. Designed to be the single source of truth for your product's positioning — bookmarkable, printable, and shareable.
-
-**Key differentiators:**
-- vs `/octave:messaging` — messaging outputs text; positioning renders it as a visual HTML system
-- vs `/octave:deck` — deck is a presentation for an audience; positioning is a reference document
-- vs `/octave:brief` — brief is account-specific; positioning is about YOUR product/company
+Generate a complete, visual Messaging & Positioning system rendered as a single stunning HTML document — eight interconnected frameworks all pulled from your Octave library and grounded in real conversation evidence. Renders as a polished, scrollable HTML document with visual grids, color-coded persona columns, funnel diagrams, timelines, and split-view canvases.
 
 ## Usage
 
@@ -20,32 +13,17 @@ Unlike `/octave:messaging` which outputs text-based frameworks, this skill rende
 /octave:positioning [section] [--product <name>] [--style <preset>]
 ```
 
-## Modes
-
-```
-/octave:positioning                           # Full 8-section exercise (default)
-/octave:positioning message-framework         # Section 1: Message Framework pyramid
-/octave:positioning anchors                   # Section 2: Positioning Anchors
-/octave:positioning strategy                  # Section 3: Positioning Strategy table
-/octave:positioning personas                  # Section 4: Persona-Based Messaging
-/octave:positioning awareness                 # Section 5: Value Prop by Awareness Stage
-/octave:positioning use-cases                 # Section 6: Use Case Messaging Canvas
-/octave:positioning lifecycle                 # Section 7: Use Case Lifecycle
-/octave:positioning homepage                  # Section 8: Homepage Messaging
-/octave:positioning --product "Platform"      # Focus on specific product
-/octave:positioning --style executive-dark    # Choose style preset
-```
-
-## Examples
-
-```
-/octave:positioning                                           # Full exercise for primary product
-/octave:positioning --product "Enterprise Platform"           # Full exercise for a specific product
-/octave:positioning message-framework                         # Just the message framework
-/octave:positioning personas --product "Analytics"            # Persona messaging for specific product
-/octave:positioning homepage                                  # Homepage messaging template
-/octave:positioning awareness --style paper-minimal           # Awareness funnel with light style
-```
+| Section arg | Framework |
+|-------------|-----------|
+| *(none)* | Full 8-section exercise (default) |
+| `message-framework` | Message Framework pyramid |
+| `anchors` | Positioning Anchors |
+| `strategy` | Positioning Strategy table |
+| `personas` | Persona-Based Messaging |
+| `awareness` | Value Prop by Awareness Stage |
+| `use-cases` | Use Case Messaging Canvas |
+| `lifecycle` | Use Case Lifecycle |
+| `homepage` | Homepage Messaging |
 
 ## Instructions
 
@@ -53,182 +31,38 @@ When the user runs `/octave:positioning`:
 
 ### Step 1: Understand the Context
 
-**Determine scope:**
-
-If no section specified, confirm full exercise:
-
-```
-I'll generate a complete Messaging & Positioning system — all 8 frameworks
-in one visual HTML document.
-
-THE 8 FRAMEWORKS
-1. Message Framework     — 3-layer pyramid: market → product → value props by persona
-2. Positioning Anchors   — Primary & secondary positioning statements
-3. Positioning Strategy  — Tactical table: buyer, use case, problems, differentiators
-4. Persona Messaging     — Core message translated per buying committee role
-5. Awareness Funnel      — Value props adapted by buyer awareness stage
-6. Use Case Canvas       — Current Way vs New Way per use case
-7. Use Case Lifecycle    — Customer journey phases with touchpoints & messaging
-8. Homepage Messaging    — Website implementation: primary vs secondary messaging
-
-PRODUCT FOCUS
-Which product should this positioning system cover?
-
-1. [Product 1 from library]
-2. [Product 2 from library]
-3. Entire company / all products
-4. Specific use case or segment
-
-Your choice:
-```
-
-If a specific section was requested, confirm and proceed directly.
+If no section specified, confirm full exercise and ask which product to focus on (list products from library, or "entire company / all products", or "specific use case or segment"). If a specific section was requested, confirm and proceed directly.
 
 ### Step 2: Octave Context Gathering
 
 Gather all library intelligence in a single pass. **Tell the user what you're researching and why.** All 8 sections share the same data pool — gather once, render many.
 
-**Call as many tools as needed to build a complete picture.** The best positioning systems come from layering multiple sources — product details + persona definitions + playbook messaging + competitive context + proof points + conversation evidence all combine to create frameworks grounded in real data.
-
-**List vs Search — when to use which:**
-
-| Tool | Purpose | Use when... |
-|------|---------|-------------|
-| `list_all_entities({ entityType })` | Fetch all entities of a type (minimal fields) | You want a quick inventory — "show me all personas" |
-| `list_entities({ entityType })` | Fetch entities with full data (paginated) | You need the actual content — "get full persona details" |
-| `get_entity({ oId })` | Deep dive on one specific entity | You found something relevant and need the complete picture |
-| `search_knowledge_base({ query })` | Semantic search across library + resources | You have a concept — "how do we position for enterprise?" |
-| `list_resources()` / `search_resources({ query })` | Uploaded docs, URLs, Google Drive files | You need reference material or source docs |
-
-**Rule of thumb:** Use `list_*` when you know *what type* of thing you want. Use `search_*` when you know *what topic* you're looking for.
-
----
-
-#### Data Gathering Matrix
-
-Every section needs data from the library. Gather it all up front:
-
-| What you need | Tool | Sections that use it |
-|---------------|------|---------------------|
-| All products | `list_all_entities({ entityType: "product" })` | All 8 |
-| Product deep dive | `get_entity({ oId: "<product_oId>" })` | All 8 |
-| All personas | `list_entities({ entityType: "persona" })` | 1, 3, 4, 5, 7, 8 |
-| All segments | `list_entities({ entityType: "segment" })` | 1, 3 |
-| All use cases | `list_entities({ entityType: "use_case" })` | 1, 3, 6, 7 |
-| All competitors | `list_all_entities({ entityType: "competitor" })` | 2, 3, 6 |
-| Competitor details | `get_entity({ oId })` | 3, 6 |
-| All playbooks | `list_all_entities({ entityType: "playbook" })` | 1, 2, 4, 5, 8 |
-| Playbook + value props | `get_playbook({ oId, includeValueProps: true })` | 1, 2, 4, 5, 8 |
-| Proof points | `list_entities({ entityType: "proof_point" })` | 2, 3, 5 |
-| References | `list_entities({ entityType: "reference" })` | 2, 3 |
-| Brand voice | `list_brand_voices()` | 8 (homepage tone) |
-| Competitive positioning | `search_knowledge_base({ query: "<product> differentiation competitive advantage", entityTypes: ["competitor", "playbook"] })` | 2, 3, 6 |
-| What resonates | `list_findings({ query: "value propositions positive reactions resonated", startDate: "<90 days ago>", eventFilters: { sentiments: ["POSITIVE"] } })` | 2, 5 |
-| What falls flat | `list_findings({ query: "objections pushback concerns", startDate: "<90 days ago>", eventFilters: { sentiments: ["NEGATIVE"] } })` | 3, 5 |
-
----
-
-**Output of this step:** Present a data summary and content outline:
-
 ```
-POSITIONING SYSTEM OUTLINE: [Product/Company]
-===============================================
+# Core entities
+list_all_entities({ entityType: "product" })         # Products to position
+list_all_entities({ entityType: "persona" })          # Buying committee roles
+list_all_entities({ entityType: "use_case" })         # Use cases for canvases
+list_all_entities({ entityType: "competitor" })        # Competitive alternatives
+list_all_entities({ entityType: "segment" })           # Target segments
 
-Product: [Name]
-Product Category: [Category from entity]
-Target Segments: [List]
-Target Personas: [List with roles]
-Use Cases: [List]
-Competitors: [List]
-Playbooks: [N] with [N] value props
-Proof Points: [N] available
-Conversation Evidence: [N] positive findings, [N] negative findings
+# Deep dives
+get_entity({ entityType: "product", oId: "<oId>" })   # Full product details
+get_playbook({ oId: "<playbook_oId>" })                # Messaging & value props
+list_value_props({ playbookOId: "<oId>" })             # Persona-specific value props
 
----
-
-SECTIONS TO GENERATE
----------------------
-
-1. Message Framework
-   Market: [Champion] + [Company Type] + [Use Case] + [Problem]
-   MVP: [Category] + [Most Compelling Capability] + [Feature] + [Main Benefit]
-   Value Props: [N] value props across [N] personas
-
-2. Positioning Anchors
-   Primary: "[Product] is a [category] for [persona] doing [use case]"
-   Secondary: [N] supporting anchors
-
-3. Positioning Strategy
-   [N] rows: competitive alternatives, problems, differentiators, proof by role
-
-4. Persona-Based Messaging
-   [N] personas: User, Champion, Decision Maker, Financial Buyer, Technical Influencer
-
-5. Value Prop by Awareness Stage
-   4 stages: Problem Unaware → Problem Aware → Solution Aware → Product Aware
-
-6. Use Case Messaging Canvas
-   [N] use cases: Current Way vs New Way
-
-7. Use Case Lifecycle
-   [N] use cases with customer journey phases
-
-8. Homepage Messaging
-   Primary (homepage): core product + persona + problem + solution
-   Secondary (other pages): additional personas, problems, capabilities
-
-Octave Sources Used:
-- Products: [list]
-- Personas: [list]
-- Segments: [list]
-- Use Cases: [list]
-- Competitors: [list]
-- Playbooks: [list] with [N] value props
-- Proof Points: [N]
-- Conversation Findings: [N]
-
----
-
-Does this look right? I can:
-1. Proceed to style selection and generation
-2. Add or remove sections
-3. Go deeper on any data area
-4. Change the product focus
+# Evidence & intelligence
+list_findings({ days: 90 })                            # What resonates / falls flat
+search_knowledge_base({ query: "competitive positioning" })
+list_brand_voices()                                    # Brand tone for homepage section
 ```
 
-**Wait for user approval before proceeding.**
+For the full entity-to-section mapping, see [data-gathering-matrix.md](references/data-gathering-matrix.md).
+
+**Output of this step:** Present a data summary listing: product, category, segments, personas, use cases, competitors, playbooks, proof points, and conversation evidence counts. Then list the 8 sections to generate with key data points for each. Ask user to approve, add/remove sections, or go deeper before proceeding.
 
 ### Step 3: Style Selection
 
-The positioning system uses the same CSS variable / style preset system as `/octave:deck`. Full preset definitions are in the deck skill's [style-presets.md](../deck/references/style-presets.md).
-
-Positioning documents default to strategic, executive-friendly presets. If `--style` was not provided, ask:
-
-```
-Pick a style for your positioning system:
-
-DARK (recommended for strategy documents)
-  1. midnight-pro      — Dark navy + blue accents. Executive feel. [DEFAULT]
-  2. executive-dark    — Charcoal + gold. Premium boardroom.
-  3. octave-brand      — Purple on navy. Product-aligned.
-
-LIGHT
-  4. paper-minimal     — Off-white + black type. Editorial.
-  5. swiss-modern      — White + red accent. Clean minimal.
-  6. soft-light        — Warm white + sage green. Calm.
-
-VIBRANT
-  7. solar-flare       — Deep orange gradients. Bold.
-  8. aurora-gradient   — Purple-to-teal. Visionary.
-
-OTHER
-  9. Use my brand      — Extract from website or provide colors
-  10. Match an existing doc — Reuse style from a previous /octave: document
-
-Your choice (number or name, or press Enter for midnight-pro):
-```
-
-If the user selects "Use my brand," follow the brand discovery flow from the deck skill (website extraction via browser-use or WebFetch, manual fallback). If they select "Match an existing doc," ask for the file path and extract its CSS variables.
+If `--style` was not provided, present the style menu from [style-selection.md](references/style-selection.md). Default is `midnight-pro`.
 
 ### Step 4: Generate HTML
 
@@ -252,233 +86,49 @@ The `.octave-positioning/` directory should be in `.gitignore`.
 
 The positioning system is a scrollable reference document — not a slide deck. Natural page scroll, sticky sidebar navigation, collapsible sections, and a print-friendly layout.
 
-The full HTML structure, section templates, and CSS component patterns are defined in the references:
+All HTML structure, base CSS, and JavaScript are defined in the references:
+- [html-architecture.md](references/html-architecture.md) — Base CSS classes, HTML skeleton, sidebar JS
 - [section-templates.md](references/section-templates.md) — HTML templates for all 8 section types
 - [section-layouts.md](references/section-layouts.md) — Section-specific CSS patterns (grids, funnels, timelines, canvases)
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Positioning System: [Product/Company]</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=[fonts]&display=swap" rel="stylesheet">
-  <style>
-    /* === CSS Variables (from chosen preset — see style-presets.md) === */
-    :root { /* ... paste chosen preset variables here ... */ }
-
-    /* === Reset & Base === */
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    html { scroll-behavior: smooth; }
-    body { background: var(--bg); color: var(--text-primary); font-family: var(--font-body); line-height: 1.6; }
-
-    /* === Document Layout (wider than brief — positioning is grid-heavy) === */
-    .doc-container { max-width: 1100px; margin: 0 auto; padding: 2rem clamp(1rem, 4vw, 3rem); }
-
-    /* === Sticky Sidebar Navigation === */
-    .sidebar { position: fixed; top: 50%; transform: translateY(-50%); right: clamp(0.5rem, 2vw, 2rem); display: flex; flex-direction: column; gap: 0.35rem; z-index: 100; }
-    .sidebar a { display: block; width: 8px; height: 8px; border-radius: 50%; background: var(--text-muted); transition: all 0.2s var(--ease); text-decoration: none; }
-    .sidebar a.active { background: var(--brand-primary); transform: scale(1.5); }
-    .sidebar a:hover { background: var(--brand-500); transform: scale(1.3); }
-
-    /* === Section Base === */
-    .section { margin-bottom: clamp(3rem, 6vh, 5rem); padding-top: 1rem; }
-    .section-number { font-family: var(--font-mono); font-size: 0.75rem; color: var(--brand-primary); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.25rem; }
-    .section-title { font-family: var(--font-display); font-size: clamp(1.4rem, 2.5vw, 2rem); font-weight: 700; margin-bottom: 0.5rem; }
-    .section-subtitle { font-size: clamp(0.85rem, 1.2vw, 1rem); color: var(--text-secondary); margin-bottom: 1.5rem; }
-
-    /* === Collapsible Sections (details/summary) === */
-    details.section { border-bottom: 1px solid var(--border); padding-bottom: 2rem; }
-    details.section summary { cursor: pointer; list-style: none; display: flex; align-items: center; gap: 0.75rem; }
-    details.section summary::before { content: "\25B6"; font-size: 0.6em; color: var(--brand-primary); transition: transform 0.2s ease; }
-    details.section[open] summary::before { transform: rotate(90deg); }
-    details.section .section-body { margin-top: 1.5rem; }
-
-    /* === Header Banner === */
-    .header-banner { padding: clamp(2rem, 5vh, 4rem) 0; border-bottom: 1px solid var(--border); margin-bottom: clamp(2rem, 4vh, 3rem); }
-    .header-banner h1 { font-family: var(--font-display); font-size: clamp(2rem, 4vw, 3.2rem); font-weight: 700; margin-bottom: 0.5rem; }
-    .header-banner .subtitle { font-size: clamp(1rem, 1.5vw, 1.25rem); color: var(--text-secondary); }
-    .meta-badges { display: flex; gap: 0.75rem; margin-top: 1.25rem; flex-wrap: wrap; }
-    .meta-badge { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.25rem 0.75rem; border-radius: var(--radius-pill); background: var(--bg-card); border: 1px solid var(--border); font-size: 0.8rem; color: var(--text-secondary); }
-
-    /* === Cards & Grids === */
-    .card { padding: clamp(1rem, 2vh, 1.5rem); border-radius: var(--radius-lg); background: var(--bg-card); border: 1px solid var(--border); }
-    .card:hover { border-color: var(--border-strong); }
-    .grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: clamp(0.75rem, 1.5vw, 1.25rem); }
-    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: clamp(0.75rem, 1.5vw, 1.25rem); }
-    .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: clamp(0.75rem, 1.5vw, 1.25rem); }
-    .grid-5 { display: grid; grid-template-columns: repeat(5, 1fr); gap: clamp(0.75rem, 1.5vw, 1rem); }
-
-    /* === Callout Box === */
-    .callout { padding: clamp(1rem, 2vh, 1.5rem); border-radius: var(--radius-lg); background: var(--bg-card); border-left: 4px solid var(--brand-primary); }
-
-    /* === Tables === */
-    .data-table { width: 100%; border-collapse: collapse; font-size: clamp(0.8rem, 1vw, 0.9rem); }
-    .data-table th { text-align: left; padding: 0.75rem; border-bottom: 2px solid var(--border-strong); color: var(--text-secondary); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
-    .data-table td { padding: 0.75rem; border-bottom: 1px solid var(--border); vertical-align: top; }
-
-    /* === Persona Colors === */
-    .persona-user { border-color: #34d399; }
-    .persona-user .persona-dot { background: #34d399; }
-    .persona-champion { border-color: #60a5fa; }
-    .persona-champion .persona-dot { background: #60a5fa; }
-    .persona-decision { border-color: #f59e0b; }
-    .persona-decision .persona-dot { background: #f59e0b; }
-    .persona-financial { border-color: #f87171; }
-    .persona-financial .persona-dot { background: #f87171; }
-    .persona-technical { border-color: #a78bfa; }
-    .persona-technical .persona-dot { background: #a78bfa; }
-    .persona-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 0.4rem; }
-
-    /* === Badges === */
-    .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: var(--radius-pill); font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; }
-    .badge-primary { background: rgba(59, 130, 246, 0.15); color: var(--brand-primary); }
-    .badge-success { background: rgba(52, 211, 153, 0.15); color: var(--success); }
-    .badge-warning { background: rgba(251, 191, 36, 0.15); color: var(--warning); }
-    .badge-error { background: rgba(248, 113, 113, 0.15); color: var(--error); }
-
-    /* === Highlighted Text (for positioning anchors) === */
-    .highlight { padding: 0.1rem 0.4rem; border-radius: 3px; font-weight: 600; }
-    .highlight-category { background: rgba(168, 85, 247, 0.2); color: #c084fc; }
-    .highlight-persona { background: rgba(59, 130, 246, 0.2); color: #93c5fd; }
-    .highlight-usecase { background: rgba(52, 211, 153, 0.2); color: #6ee7b7; }
-    .highlight-problem { background: rgba(248, 113, 113, 0.2); color: #fca5a5; }
-    .highlight-feature { background: rgba(251, 191, 36, 0.2); color: #fcd34d; }
-
-    /* === Section-specific layouts — see references/section-layouts.md === */
-    /* Included inline: message framework bands, funnel columns, timeline, canvas split */
-
-    /* === Responsive === */
-    @media (max-width: 768px) {
-      .grid-2, .grid-3, .grid-4, .grid-5 { grid-template-columns: 1fr; }
-      .sidebar { display: none; }
-      .funnel-grid { grid-template-columns: 1fr; }
-      .canvas-split { grid-template-columns: 1fr; }
-      .timeline-phases { overflow-x: auto; }
-    }
-
-    /* === Print === */
-    @media print {
-      .sidebar { display: none; }
-      details.section { break-inside: avoid; }
-      details.section[open] { break-inside: avoid; }
-      .card { break-inside: avoid; }
-      body { color: #111; background: white; }
-      .meta-badge { border: 1px solid #ccc; background: transparent; }
-    }
-
-    /* === prefers-reduced-motion === */
-    @media (prefers-reduced-motion: reduce) {
-      * { transition: none !important; animation: none !important; }
-    }
-  </style>
-</head>
-<body>
-
-  <!-- Sidebar Navigation Dots -->
-  <nav class="sidebar" id="sidebar-nav">
-    <!-- Generated by JS: one dot per section -->
-  </nav>
-
-  <div class="doc-container">
-
-    <!-- Header Banner -->
-    <header class="header-banner" id="section-header">
-      <p style="color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.8rem; margin-bottom: 0.5rem;">Messaging & Positioning System</p>
-      <h1>[Product / Company Name]</h1>
-      <p class="subtitle">[Product category] for [primary persona] in [target segment]</p>
-      <div class="meta-badges">
-        <span class="meta-badge">Generated [Date]</span>
-        <span class="meta-badge">[N] Personas</span>
-        <span class="meta-badge">[N] Use Cases</span>
-        <span class="meta-badge">[N] Value Props</span>
-        <span class="meta-badge">[N] Proof Points</span>
-      </div>
-    </header>
-
-    <!-- Section 1: Message Framework -->
-    <!-- Section 2: Positioning Anchors -->
-    <!-- Section 3: Positioning Strategy -->
-    <!-- Section 4: Persona-Based Messaging -->
-    <!-- Section 5: Value Prop by Awareness Stage -->
-    <!-- Section 6: Use Case Messaging Canvas -->
-    <!-- Section 7: Use Case Lifecycle -->
-    <!-- Section 8: Homepage Messaging -->
-    <!-- See references/section-templates.md for full HTML per section -->
-
-  </div>
-
-  <script>
-    // Sidebar: generate dots from .section elements
-    // Intersection Observer highlights active section dot
-    // Smooth scroll on dot click
-    // Open all details on print
-    (function() {
-      const sections = document.querySelectorAll('.section');
-      const sidebar = document.getElementById('sidebar-nav');
-      sections.forEach((section, i) => {
-        const dot = document.createElement('a');
-        dot.href = '#' + section.id;
-        dot.title = section.querySelector('.section-title')?.textContent || '';
-        if (i === 0) dot.classList.add('active');
-        sidebar.appendChild(dot);
-      });
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            sidebar.querySelectorAll('a').forEach(d => d.classList.remove('active'));
-            const active = sidebar.querySelector('a[href="#' + entry.target.id + '"]');
-            if (active) active.classList.add('active');
-          }
-        });
-      }, { threshold: 0.2 });
-      sections.forEach(s => observer.observe(s));
-      window.onbeforeprint = () => {
-        document.querySelectorAll('details.section').forEach(d => d.open = true);
-      };
-    })();
-  </script>
-
-</body>
-</html>
-```
-
-**Self-contained:** Inline CSS, zero external dependencies (except Google Fonts). No JavaScript frameworks.
-
-**Key differences from brief/battlecard-doc HTML:**
-- **Max-width 1100px** (wider — positioning frameworks need horizontal space for grids)
-- **Persona color system** — consistent color coding across all 8 sections (User=green, Champion=blue, Decision Maker=amber, Financial Buyer=red, Technical Influencer=purple)
-- **Highlight classes** — for styling positioning anchor keywords (category, persona, use case, problem, feature)
-- **Grid-4 and Grid-5** — for persona columns and awareness stage columns
-- **Section numbering** — "Section 01" labels for clear progression through the exercise
-
 #### Content Population
 
-Populate each section using the templates in [section-templates.md](references/section-templates.md). Each section has:
-- A **section number** and **title** in the summary
-- A **subtitle** explaining what this framework answers
-- The **visual layout** appropriate to that framework type
-- **Real data** from the Octave context gathered in Step 2
-
-For each section, use `generate_content` to synthesize the gathered library data into the framework structure:
+For each section, use `generate_content` to synthesize library data, then render into the HTML templates from [section-templates.md](references/section-templates.md):
 
 ```
 generate_content({
-  instructions: "Generate content for the [Section Name] framework.
-    Structure: [specific structure for this section — see section-templates.md]
+  instructions: "Generate the Message Framework pyramid. Three layers:
+    1. Market Message: [champion] + [company type] + [use case] + [problem]
+    2. Product Message: [category] + [capability] + [feature] + [benefit]
+    3. Value Props: one row per persona-use case combination.
     Ground everything in the library data provided. Do not invent data.",
-  customContext: "<relevant subset of gathered library intelligence>"
+  customContext: "<product entities, persona entities, playbook value props>"
 })
 ```
 
-Then render the generated content into the HTML template for that section.
+Example HTML output for a Message Framework section:
+
+```html
+<section id="message-framework" class="framework-section">
+  <div class="section-header">
+    <span class="section-number">01</span>
+    <h2>Message Framework</h2>
+    <p class="subtitle">The pyramid that connects market need to product value</p>
+  </div>
+  <div class="pyramid-grid">
+    <div class="pyramid-layer market">
+      <h3>Market Message</h3>
+      <p>Revenue leaders at B2B SaaS companies struggle to align
+         GTM teams around consistent messaging across channels.</p>
+    </div>
+    <!-- product layer + value prop rows follow same pattern -->
+  </div>
+</section>
+```
+
+Apply this pattern to all 8 sections using the layouts from [section-layouts.md](references/section-layouts.md).
 
 #### Content Density Guidelines
-
-Each section has specific content limits to keep the document scannable:
 
 | Section | Content Limit |
 |---------|--------------|
@@ -486,141 +136,39 @@ Each section has specific content limits to keep the document scannable:
 | Positioning Anchors | 1 primary anchor + 3-5 secondary anchors + 2-3 combination examples |
 | Positioning Strategy | 1 summary row + up to 6 comparison rows (competitive alternatives) |
 | Persona Messaging | Up to 5 persona columns (User, Champion, Decision Maker, Financial Buyer, Technical Influencer) |
-| Awareness Funnel | 4 fixed columns × 3 rows (Lead with, Earn trust by, To convince them) |
+| Awareness Funnel | 4 fixed columns x 3 rows (Lead with, Earn trust by, To convince them) |
 | Use Case Canvas | 1 canvas per use case, up to 3 use cases |
 | Use Case Lifecycle | 6-8 journey phases per use case |
 | Homepage Messaging | 1 primary column + 1 secondary column with up to 5 expansion rows |
 
 ### Step 5: Delivery
 
-After generating the HTML file:
+Open the document in the default browser. Present: file path, style, product, sections generated, data source counts, and navigation tips (scroll, sidebar dots, collapsible sections, Cmd+P for PDF).
 
-1. **Open the document** in the default browser
-2. **Present a summary:**
+Offer follow-up actions: adjust/expand a section, go deeper on a framework, generate campaign content (`/octave:campaign`), create a sales deck (`/octave:deck`), save positioning back to library, change style, or export PDF.
 
-```
-POSITIONING SYSTEM READY
-=========================
-
-Folder: .octave-positioning/<product>-<date>/
-File:   .octave-positioning/<product>-<date>/positioning-system.html
-Style:  [Preset name]
-
-Product: [Product name]
-Sections: [N] frameworks generated
-Data sources: [N] personas, [N] use cases, [N] value props, [N] proof points
-
-Navigation:
-- Scroll through all 8 frameworks
-- Sidebar dots on the right track your position
-- Click section headers to collapse/expand
-- Print-friendly: Cmd+P / Ctrl+P for clean PDF
-
----
-
-Want me to:
-1. Adjust or expand a section
-2. Go deeper on a specific framework
-3. Generate campaign content from this positioning (/octave:campaign)
-4. Create a sales deck from this (/octave:deck)
-5. Save positioning statements back to library
-6. Change the style
-7. Export as PDF (print dialog)
-8. Done
-```
-
-**If the user wants to save back to library:**
+**Save back to library** (if requested):
 
 ```
-# Save positioning statements to product entity
 update_entity({
-  entityType: "product",
-  oId: "<product_oId>",
-  instructions: "Update positioning to: [primary positioning anchor]. Category: [category]. Primary value prop: [primary VP]."
+  entityType: "product", oId: "<product_oId>",
+  instructions: "Update positioning to: [primary anchor]. Category: [category]."
 })
-
-# Add or update value props in playbook
 add_value_props({
   playbookOId: "<playbook_oId>",
-  instructions: "<persona-specific value props from the message framework>",
+  instructions: "<persona-specific value props from message framework>",
   numValuesPerPersona: 3
 })
 ```
 
-## MCP Tools Used
-
-### Library — Fetching Entities
-- `list_all_entities` — Quick scan of all entities of a type (products, personas, segments, use cases, competitors, playbooks)
-- `list_entities` — Fetch entities with full data and pagination (personas, proof points, references, use cases)
-- `get_entity` — Deep dive on one specific entity (product, competitor)
-- `get_playbook` — Retrieve a playbook with full content and value props
-- `list_value_props` — Value propositions for a specific playbook
-
-### Library — Searching
-- `search_knowledge_base` — Semantic search across library entities and resources (competitive positioning, differentiation)
-- `search_resources` — Search uploaded docs and reference material
-
-### Intelligence & Signals
-- `list_findings` — Conversation findings: what resonates (positive) and what falls flat (negative)
-- `list_brand_voices` — Brand voice for homepage messaging tone
-
-### Content Generation
-- `generate_content` — Synthesize library data into framework structures
-
-### Library Updates (Post-Generation)
-- `update_entity` — Save positioning statements back to product entity
-- `add_value_props` — Save value props to playbooks
-
 ## Error Handling
 
-**No Products Found:**
-> No products in your library.
->
-> The positioning system needs at least one product to build frameworks around.
-> Run `/octave:library create product` first, or describe your product and I'll work from that.
-
-**No Personas Found:**
-> No personas defined yet.
->
-> I can generate a basic positioning system, but persona-specific sections (Message Framework value props, Persona Messaging, Homepage expansion) will be limited.
-> Run `/octave:library create persona` to add personas.
-
-**No Use Cases Found:**
-> No use cases defined.
->
-> Sections 6 (Use Case Canvas) and 7 (Use Case Lifecycle) require use cases. I'll skip them and generate the other 6 sections.
-> Run `/octave:library create use_case` to add use cases.
-
-**No Playbooks or Value Props:**
-> No playbooks or value propositions found.
->
-> The Message Framework and Persona Messaging sections will use product-level information only. For richer output, create a playbook with value propositions.
-
-**No Competitors Found:**
-> No competitors in your library.
->
-> Sections 3 (Positioning Strategy) and 6 (Use Case Canvas) will omit competitive comparisons. The other sections will generate from product and persona data.
-> Run `/octave:library create competitor` to add competitors.
-
-**No Conversation Evidence:**
-> No conversation findings available.
->
-> The positioning system will be built entirely from library data. As your team logs calls, re-running this skill will surface what resonates and what doesn't — making each iteration sharper.
-
-**Octave Connection Failed:**
-> Could not connect to your Octave workspace.
->
-> The positioning system builder needs Octave data to generate useful frameworks. Without it, most sections would be empty.
-> To reconnect: check your MCP configuration or run `/octave:workspace status`
-
-## Related Skills
-
-- `/octave:messaging` — Text-based messaging frameworks (this is the visual counterpart)
-- `/octave:deck` — Build a presentation from your positioning
-- `/octave:campaign` — Generate campaign content grounded in your positioning
-- `/octave:launch` — Launch plan using this positioning as the messaging foundation
-- `/octave:brief` — Account-specific prep document (positioning is product-level)
-- `/octave:battlecard` — Competitive intelligence (feeds into Section 3: Strategy)
-- `/octave:enablement` — Sales enablement materials using your positioning
-- `/octave:one-pager` — Customer-facing document built from positioning
-- `/octave:library` — Update library entities with finalized positioning
+| Scenario | Response |
+|----------|----------|
+| No products | Require at least one product; suggest `/octave:library create product` |
+| No personas | Generate basic system; persona sections limited; suggest creating personas |
+| No use cases | Skip Sections 6-7; generate remaining 6 sections |
+| No playbooks/value props | Use product-level info only; suggest creating a playbook |
+| No competitors | Omit competitive comparisons in Sections 3 and 6 |
+| No conversation evidence | Build from library data only; suggest re-running after logging calls |
+| Octave connection failed | Cannot proceed without Octave data; check MCP config |

--- a/skills/positioning/references/data-gathering-matrix.md
+++ b/skills/positioning/references/data-gathering-matrix.md
@@ -1,0 +1,35 @@
+# Data Gathering Matrix
+
+Every section needs data from the Octave library. Gather it all up front in a single pass.
+
+## Tool Selection Guide
+
+| Tool | Purpose | Use when... |
+|------|---------|-------------|
+| `list_all_entities({ entityType })` | Fetch all entities of a type (minimal fields) | You want a quick inventory — "show me all personas" |
+| `list_entities({ entityType })` | Fetch entities with full data (paginated) | You need the actual content — "get full persona details" |
+| `get_entity({ oId })` | Deep dive on one specific entity | You found something relevant and need the complete picture |
+| `search_knowledge_base({ query })` | Semantic search across library + resources | You have a concept — "how do we position for enterprise?" |
+| `list_resources()` / `search_resources({ query })` | Uploaded docs, URLs, Google Drive files | You need reference material or source docs |
+
+**Rule of thumb:** Use `list_*` when you know *what type* of thing you want. Use `search_*` when you know *what topic* you're looking for.
+
+## Entity-to-Section Mapping
+
+| What you need | Tool | Sections that use it |
+|---------------|------|---------------------|
+| All products | `list_all_entities({ entityType: "product" })` | All 8 |
+| Product deep dive | `get_entity({ oId: "<product_oId>" })` | All 8 |
+| All personas | `list_entities({ entityType: "persona" })` | 1, 3, 4, 5, 7, 8 |
+| All segments | `list_entities({ entityType: "segment" })` | 1, 3 |
+| All use cases | `list_entities({ entityType: "use_case" })` | 1, 3, 6, 7 |
+| All competitors | `list_all_entities({ entityType: "competitor" })` | 2, 3, 6 |
+| Competitor details | `get_entity({ oId })` | 3, 6 |
+| All playbooks | `list_all_entities({ entityType: "playbook" })` | 1, 2, 4, 5, 8 |
+| Playbook + value props | `get_playbook({ oId, includeValueProps: true })` | 1, 2, 4, 5, 8 |
+| Proof points | `list_entities({ entityType: "proof_point" })` | 2, 3, 5 |
+| References | `list_entities({ entityType: "reference" })` | 2, 3 |
+| Brand voice | `list_brand_voices()` | 8 (homepage tone) |
+| Competitive positioning | `search_knowledge_base({ query: "<product> differentiation competitive advantage", entityTypes: ["competitor", "playbook"] })` | 2, 3, 6 |
+| What resonates | `list_findings({ query: "value propositions positive reactions resonated", startDate: "<90 days ago>", eventFilters: { sentiments: ["POSITIVE"] } })` | 2, 5 |
+| What falls flat | `list_findings({ query: "objections pushback concerns", startDate: "<90 days ago>", eventFilters: { sentiments: ["NEGATIVE"] } })` | 3, 5 |

--- a/skills/positioning/references/html-architecture.md
+++ b/skills/positioning/references/html-architecture.md
@@ -1,0 +1,213 @@
+# HTML Architecture Reference
+
+Self-contained HTML structure for the Positioning System document. No external dependencies except Google Fonts. Everything else inlined.
+
+**Key differences from brief/battlecard-doc HTML:**
+- **Max-width 1100px** (wider — positioning frameworks need horizontal space for grids)
+- **Persona color system** — consistent color coding across all 8 sections (User=green, Champion=blue, Decision Maker=amber, Financial Buyer=red, Technical Influencer=purple)
+- **Highlight classes** — for styling positioning anchor keywords (category, persona, use case, problem, feature)
+- **Grid-4 and Grid-5** — for persona columns and awareness stage columns
+- **Section numbering** — "Section 01" labels for clear progression through the exercise
+
+---
+
+## Base CSS
+
+Paste the chosen style preset variables (from [style-presets.md](../../deck/references/style-presets.md)) into `:root`.
+
+```css
+/* === CSS Variables (from chosen preset — see style-presets.md) === */
+:root { /* ... paste chosen preset variables here ... */ }
+
+/* === Reset & Base === */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body { background: var(--bg); color: var(--text-primary); font-family: var(--font-body); line-height: 1.6; }
+
+/* === Document Layout (wider than brief — positioning is grid-heavy) === */
+.doc-container { max-width: 1100px; margin: 0 auto; padding: 2rem clamp(1rem, 4vw, 3rem); }
+
+/* === Sticky Sidebar Navigation === */
+.sidebar { position: fixed; top: 50%; transform: translateY(-50%); right: clamp(0.5rem, 2vw, 2rem); display: flex; flex-direction: column; gap: 0.35rem; z-index: 100; }
+.sidebar a { display: block; width: 8px; height: 8px; border-radius: 50%; background: var(--text-muted); transition: all 0.2s var(--ease); text-decoration: none; }
+.sidebar a.active { background: var(--brand-primary); transform: scale(1.5); }
+.sidebar a:hover { background: var(--brand-500); transform: scale(1.3); }
+
+/* === Section Base === */
+.section { margin-bottom: clamp(3rem, 6vh, 5rem); padding-top: 1rem; }
+.section-number { font-family: var(--font-mono); font-size: 0.75rem; color: var(--brand-primary); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.25rem; }
+.section-title { font-family: var(--font-display); font-size: clamp(1.4rem, 2.5vw, 2rem); font-weight: 700; margin-bottom: 0.5rem; }
+.section-subtitle { font-size: clamp(0.85rem, 1.2vw, 1rem); color: var(--text-secondary); margin-bottom: 1.5rem; }
+
+/* === Collapsible Sections (details/summary) === */
+details.section { border-bottom: 1px solid var(--border); padding-bottom: 2rem; }
+details.section summary { cursor: pointer; list-style: none; display: flex; align-items: center; gap: 0.75rem; }
+details.section summary::before { content: "\25B6"; font-size: 0.6em; color: var(--brand-primary); transition: transform 0.2s ease; }
+details.section[open] summary::before { transform: rotate(90deg); }
+details.section .section-body { margin-top: 1.5rem; }
+
+/* === Header Banner === */
+.header-banner { padding: clamp(2rem, 5vh, 4rem) 0; border-bottom: 1px solid var(--border); margin-bottom: clamp(2rem, 4vh, 3rem); }
+.header-banner h1 { font-family: var(--font-display); font-size: clamp(2rem, 4vw, 3.2rem); font-weight: 700; margin-bottom: 0.5rem; }
+.header-banner .subtitle { font-size: clamp(1rem, 1.5vw, 1.25rem); color: var(--text-secondary); }
+.meta-badges { display: flex; gap: 0.75rem; margin-top: 1.25rem; flex-wrap: wrap; }
+.meta-badge { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.25rem 0.75rem; border-radius: var(--radius-pill); background: var(--bg-card); border: 1px solid var(--border); font-size: 0.8rem; color: var(--text-secondary); }
+
+/* === Cards & Grids === */
+.card { padding: clamp(1rem, 2vh, 1.5rem); border-radius: var(--radius-lg); background: var(--bg-card); border: 1px solid var(--border); }
+.card:hover { border-color: var(--border-strong); }
+.grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: clamp(0.75rem, 1.5vw, 1.25rem); }
+.grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: clamp(0.75rem, 1.5vw, 1.25rem); }
+.grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: clamp(0.75rem, 1.5vw, 1.25rem); }
+.grid-5 { display: grid; grid-template-columns: repeat(5, 1fr); gap: clamp(0.75rem, 1.5vw, 1rem); }
+
+/* === Callout Box === */
+.callout { padding: clamp(1rem, 2vh, 1.5rem); border-radius: var(--radius-lg); background: var(--bg-card); border-left: 4px solid var(--brand-primary); }
+
+/* === Tables === */
+.data-table { width: 100%; border-collapse: collapse; font-size: clamp(0.8rem, 1vw, 0.9rem); }
+.data-table th { text-align: left; padding: 0.75rem; border-bottom: 2px solid var(--border-strong); color: var(--text-secondary); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
+.data-table td { padding: 0.75rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+
+/* === Persona Colors === */
+.persona-user { border-color: #34d399; }
+.persona-user .persona-dot { background: #34d399; }
+.persona-champion { border-color: #60a5fa; }
+.persona-champion .persona-dot { background: #60a5fa; }
+.persona-decision { border-color: #f59e0b; }
+.persona-decision .persona-dot { background: #f59e0b; }
+.persona-financial { border-color: #f87171; }
+.persona-financial .persona-dot { background: #f87171; }
+.persona-technical { border-color: #a78bfa; }
+.persona-technical .persona-dot { background: #a78bfa; }
+.persona-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 0.4rem; }
+
+/* === Badges === */
+.badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: var(--radius-pill); font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; }
+.badge-primary { background: rgba(59, 130, 246, 0.15); color: var(--brand-primary); }
+.badge-success { background: rgba(52, 211, 153, 0.15); color: var(--success); }
+.badge-warning { background: rgba(251, 191, 36, 0.15); color: var(--warning); }
+.badge-error { background: rgba(248, 113, 113, 0.15); color: var(--error); }
+
+/* === Highlighted Text (for positioning anchors) === */
+.highlight { padding: 0.1rem 0.4rem; border-radius: 3px; font-weight: 600; }
+.highlight-category { background: rgba(168, 85, 247, 0.2); color: #c084fc; }
+.highlight-persona { background: rgba(59, 130, 246, 0.2); color: #93c5fd; }
+.highlight-usecase { background: rgba(52, 211, 153, 0.2); color: #6ee7b7; }
+.highlight-problem { background: rgba(248, 113, 113, 0.2); color: #fca5a5; }
+.highlight-feature { background: rgba(251, 191, 36, 0.2); color: #fcd34d; }
+
+/* === Section-specific layouts — see section-layouts.md === */
+
+/* === Responsive === */
+@media (max-width: 768px) {
+  .grid-2, .grid-3, .grid-4, .grid-5 { grid-template-columns: 1fr; }
+  .sidebar { display: none; }
+  .funnel-grid { grid-template-columns: 1fr; }
+  .canvas-split { grid-template-columns: 1fr; }
+  .timeline-phases { overflow-x: auto; }
+}
+
+/* === Print === */
+@media print {
+  .sidebar { display: none; }
+  details.section { break-inside: avoid; }
+  details.section[open] { break-inside: avoid; }
+  .card { break-inside: avoid; }
+  body { color: #111; background: white; }
+  .meta-badge { border: 1px solid #ccc; background: transparent; }
+}
+
+/* === prefers-reduced-motion === */
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation: none !important; }
+}
+```
+
+---
+
+## HTML Skeleton
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Positioning System: [Product/Company]</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=[fonts]&display=swap" rel="stylesheet">
+  <style>
+    /* Paste base CSS above + section layouts from section-layouts.md */
+  </style>
+</head>
+<body>
+
+  <!-- Sidebar Navigation Dots -->
+  <nav class="sidebar" id="sidebar-nav">
+    <!-- Generated by JS: one dot per section -->
+  </nav>
+
+  <div class="doc-container">
+
+    <!-- Header Banner -->
+    <header class="header-banner" id="section-header">
+      <p style="color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.8rem; margin-bottom: 0.5rem;">Messaging & Positioning System</p>
+      <h1>[Product / Company Name]</h1>
+      <p class="subtitle">[Product category] for [primary persona] in [target segment]</p>
+      <div class="meta-badges">
+        <span class="meta-badge">Generated [Date]</span>
+        <span class="meta-badge">[N] Personas</span>
+        <span class="meta-badge">[N] Use Cases</span>
+        <span class="meta-badge">[N] Value Props</span>
+        <span class="meta-badge">[N] Proof Points</span>
+      </div>
+    </header>
+
+    <!-- Section 1: Message Framework -->
+    <!-- Section 2: Positioning Anchors -->
+    <!-- Section 3: Positioning Strategy -->
+    <!-- Section 4: Persona-Based Messaging -->
+    <!-- Section 5: Value Prop by Awareness Stage -->
+    <!-- Section 6: Use Case Messaging Canvas -->
+    <!-- Section 7: Use Case Lifecycle -->
+    <!-- Section 8: Homepage Messaging -->
+    <!-- See section-templates.md for full HTML per section -->
+
+  </div>
+
+  <script>
+    // Sidebar: generate dots from .section elements
+    // Intersection Observer highlights active section dot
+    // Smooth scroll on dot click
+    // Open all details on print
+    (function() {
+      const sections = document.querySelectorAll('.section');
+      const sidebar = document.getElementById('sidebar-nav');
+      sections.forEach((section, i) => {
+        const dot = document.createElement('a');
+        dot.href = '#' + section.id;
+        dot.title = section.querySelector('.section-title')?.textContent || '';
+        if (i === 0) dot.classList.add('active');
+        sidebar.appendChild(dot);
+      });
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            sidebar.querySelectorAll('a').forEach(d => d.classList.remove('active'));
+            const active = sidebar.querySelector('a[href="#' + entry.target.id + '"]');
+            if (active) active.classList.add('active');
+          }
+        });
+      }, { threshold: 0.2 });
+      sections.forEach(s => observer.observe(s));
+      window.onbeforeprint = () => {
+        document.querySelectorAll('details.section').forEach(d => d.open = true);
+      };
+    })();
+  </script>
+
+</body>
+</html>
+```

--- a/skills/positioning/references/style-selection.md
+++ b/skills/positioning/references/style-selection.md
@@ -1,0 +1,39 @@
+# Style Selection Reference
+
+The positioning system uses the same CSS variable / style preset system as `/octave:deck`. Full preset definitions are in the deck skill's [style-presets.md](../../deck/references/style-presets.md).
+
+Positioning documents default to strategic, executive-friendly presets.
+
+## Style Menu
+
+Present this menu if `--style` was not provided:
+
+```
+Pick a style for your positioning system:
+
+DARK (recommended for strategy documents)
+  1. midnight-pro      — Dark navy + blue accents. Executive feel. [DEFAULT]
+  2. executive-dark    — Charcoal + gold. Premium boardroom.
+  3. octave-brand      — Purple on navy. Product-aligned.
+
+LIGHT
+  4. paper-minimal     — Off-white + black type. Editorial.
+  5. swiss-modern      — White + red accent. Clean minimal.
+  6. soft-light        — Warm white + sage green. Calm.
+
+VIBRANT
+  7. solar-flare       — Deep orange gradients. Bold.
+  8. aurora-gradient   — Purple-to-teal. Visionary.
+
+OTHER
+  9. Use my brand      — Extract from website or provide colors
+  10. Match an existing doc — Reuse style from a previous /octave: document
+
+Your choice (number or name, or press Enter for midnight-pro):
+```
+
+## Brand Discovery
+
+If the user selects "Use my brand," follow the brand discovery flow from the deck skill (website extraction via browser-use or WebFetch, manual fallback).
+
+If they select "Match an existing doc," ask for the file path and extract its CSS variables.


### PR DESCRIPTION
Hey @jtemps 👋

36 skills covering the full GTM lifecycle from ICP refinement and deal coaching all the way to qualification agent diagnostics with the new qual-doctor. This is the most complete sales/marketing skill suite I've come across. The workflow definitions tying skills into multi-step pipelines (competitive-deal-prep, full-outbound-pipeline) show real operational thinking, not just isolated prompts. I'd like to suggest some improvements to a few of the skill files.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="910" alt="score_card" src="https://github.com/user-attachments/assets/a96c888c-b206-4567-ac2f-081244178f53" />


<details>
<summary>What changed</summary>

The main theme across all five skills was **progressive disclosure** extracting verbose inline content (output templates, CSS/HTML scaffolding, tool reference tables, timing tables) into `references/` files so the main SKILL.md stays lean and focused on workflow logic.

**battlecard** (+18%)
- Extracted 6 mode-specific output templates into `references/` (full-battlecard, displacement, traps, objections, compare, landscape)
- Added data sufficiency validation checkpoint after intelligence gathering
- Condensed interactive menus and error handling to compact formats

**campaign** (+15%)
- Extracted channel-specific MCP tool calls and output templates into `references/CHANNEL-TEMPLATES.md`
- Moved tool reference tables into `references/MCP-TOOLS.md`
- Added Step 6: Validate Generated Content (brand voice, proof points, character limits, cross-channel consistency)
- Condensed interactive prompts to brief descriptions

**meeting-prep** (+13%)
- Extracted CSS/HTML template into `references/battle-plan-template.html`
- Moved MCP tool tables into `references/mcp-tool-reference.md`
- Moved duration timing tables into `references/game-plan-timing.md`
- Added specific inline MCP tool call examples (enrich_person, enrich_company, list_findings, etc.)
- Condensed user prompts, error handling, and delivery template

**positioning** (+10%)
- Extracted CSS/HTML architecture into `references/html-architecture.md`
- Moved data gathering matrix into `references/data-gathering-matrix.md`
- Moved style selection menu into `references/style-selection.md`
- Added concrete inline tool calls and HTML code example
- Removed redundant "Key differentiators" block
- Condensed error handling and delivery template

**deal-coach** (+4%)
- Extracted 4 mode-specific templates into `references/` (roleplay, microsite, deck, quiz)
- Consolidated repeated content (duplicate output directory, repeated stage descriptions)
- Trimmed verbose AskUserQuestion option descriptions
- Condensed error handling from blockquotes to compact table

All domain expertise, MCP tool calls, and workflow logic are fully preserved. Only verbose templates and boilerplate were moved to reference files.

</details>

Honest disclosure. I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@yogesh-tessl](https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏