### PR TITLE
Add Codex plugin generator + publish workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "url": "https://octavehq.com"
   },
   "metadata": {
-    "description": "Official Claude Code plugins for Octave - GTM knowledge base integration for positioning, research, content generation, and sales enablement",
+    "description": "Official Octave plugins — GTM knowledge base integration for positioning, research, content generation, and sales enablement",
     "pluginRoot": "./"
   },
   "plugins": [
     {
       "name": "octave",
       "source": "./",
-      "description": "Access Octave's GTM knowledge base directly from Claude Code for positioning, research, content generation, and sales enablement",
+      "description": "Access Octave's GTM knowledge base for positioning, research, content generation, and sales enablement",
       "version": "1.8.0",
       "author": {
         "name": "Octave",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octave",
   "version": "1.8.0",
-  "description": "Octave GTM knowledge base integration for Claude Code - provides bidirectional access to personas, playbooks, messaging, and more. Give Claude grounded context for your GTM motions.",
+  "description": "Octave GTM knowledge base integration — bidirectional access to personas, playbooks, messaging, and more. Grounds your AI assistant in your GTM context.",
   "author": {
     "name": "Octave",
     "url": "https://octavehq.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octave",
   "version": "1.8.0",
-  "description": "Octave GTM knowledge base integration — bidirectional access to personas, playbooks, messaging, and more. Grounds your AI assistant in your GTM context.",
+  "description": "Octave GTM knowledge base integration for Claude Code and OpenAI Codex — provides bidirectional access to personas, playbooks, messaging, and more. Give Claude and Codex grounded context for your GTM motions.",
   "author": {
     "name": "Octave",
     "url": "https://octavehq.com"

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -1,0 +1,43 @@
+name: Publish Codex build
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out lfgtm (source of truth)
+        uses: actions/checkout@v4
+
+      - name: Build Codex artifact
+        run: ./scripts/build-codex.sh
+
+      - name: Check out lfgtm-codex (target)
+        uses: actions/checkout@v4
+        with:
+          repository: octavehq/lfgtm-codex
+          token: ${{ secrets.CODEX_REPO_PAT }}
+          path: _codex-repo
+
+      - name: Sync artifact into target repo
+        run: |
+          # Wipe everything except .git so deletions propagate, then copy artifact
+          find _codex-repo -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          cp -R build/codex/. _codex-repo/
+
+      - name: Commit and push
+        working-directory: _codex-repo
+        run: |
+          git config user.name  "octave-bot"
+          git config user.email "bot@octavehq.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes."
+            exit 0
+          fi
+          git commit -m "Sync from lfgtm ${{ github.ref_name }}"
+          git tag "${{ github.ref_name }}"
+          git push origin HEAD --tags

--- a/scripts/build-codex.sh
+++ b/scripts/build-codex.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Generate a Codex-compatible plugin from this Claude Code plugin.
+# Output: build/codex/  (gitignored — pushed to the lfgtm-codex repo by CI)
+#
+# Run locally:   ./scripts/build-codex.sh
+# In CI:         same, then commit build/codex/ to the lfgtm-codex repo.
+
+set -euo pipefail
+
+SRC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="$SRC_ROOT/build/codex"
+
+# ---- toggles ----------------------------------------------------------------
+NAMESPACE_PREFIX="octave-"   # "" to keep bare names; "octave-" to rename skills/foo → octave-foo
+CONVERT_AGENTS="drop"        # "drop" | "skills" (convert agents/*.md to skills)
+# -----------------------------------------------------------------------------
+
+command -v jq >/dev/null || { echo "jq required"; exit 1; }
+
+echo "→ cleaning $OUT"
+rm -rf "$OUT"
+mkdir -p "$OUT/.codex-plugin" "$OUT/skills" "$OUT/workflows" "$OUT/.agents/plugins"
+
+# ----- NOTE on MCP config -----
+# Codex's MCP config is TOML (~/.codex/config.toml with [mcp_servers.<name>] tables).
+# Users add their own workspace-specific Octave server via `codex mcp add`. The plugin
+# itself ships no MCP file — matching the Claude plugin's pattern.
+
+# 1. plugin.json: preserve name/version/description/author, add Codex pointers
+echo "→ .codex-plugin/plugin.json"
+jq '{
+  name, version, description, author,
+  skills: "./skills/",
+  interface: {
+    displayName: "Octave GTM",
+    shortDescription: .description,
+    category: "Productivity"
+  }
+}' "$SRC_ROOT/.claude-plugin/plugin.json" \
+  > "$OUT/.codex-plugin/plugin.json"
+
+# 2. marketplace.json: Codex schema is different from Claude's — rebuild from scratch
+echo "→ .agents/plugins/marketplace.json"
+jq '{
+  name: .name,
+  interface: { displayName: "Octave GTM Plugins" },
+  plugins: [
+    .plugins[] | {
+      name, description,
+      source: { source: "local", path: "./" },
+      policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
+      category: "Productivity"
+    }
+  ]
+}' "$SRC_ROOT/.claude-plugin/marketplace.json" \
+  > "$OUT/.agents/plugins/marketplace.json"
+
+# 3. skills/: copy and optionally rename + rewrite inline refs
+echo "→ skills/ (prefix='$NAMESPACE_PREFIX')"
+for dir in "$SRC_ROOT"/skills/*/; do
+  src_name="$(basename "$dir")"
+  dst_name="${NAMESPACE_PREFIX}${src_name}"
+  cp -R "$dir" "$OUT/skills/$dst_name"
+
+  skill_md="$OUT/skills/$dst_name/SKILL.md"
+
+  # Rewrite the frontmatter name field
+  if [[ -n "$NAMESPACE_PREFIX" ]]; then
+    # YAML name: field (first occurrence, inside frontmatter)
+    awk -v new="$dst_name" '
+      BEGIN { in_fm=0; done=0 }
+      /^---$/ { in_fm = !in_fm; print; next }
+      in_fm && !done && /^name:/ { print "name: " new; done=1; next }
+      { print }
+    ' "$skill_md" > "$skill_md.tmp" && mv "$skill_md.tmp" "$skill_md"
+  fi
+
+  # Rewrite inline references: /octave:foo → /octave-foo
+  sed -i.bak 's#/octave:\([a-z][a-z0-9-]*\)#/octave-\1#g' "$skill_md"
+  rm -f "$skill_md.bak"
+done
+
+# 4. workflows/: plain markdown, safe to copy as-is
+echo "→ workflows/"
+cp -R "$SRC_ROOT"/workflows/*.md "$OUT/workflows/"
+
+# 5. agents/: no Codex equivalent
+case "$CONVERT_AGENTS" in
+  drop)
+    echo "→ agents/ dropped (no Codex equivalent)"
+    ;;
+  skills)
+    echo "→ agents/ converted to skills/ (invocation semantics differ — see README note)"
+    mkdir -p "$OUT/skills"
+    for f in "$SRC_ROOT"/agents/*.md; do
+      base="$(basename "$f" .md)"
+      dst="$OUT/skills/${NAMESPACE_PREFIX}${base}"
+      mkdir -p "$dst"
+      cp "$f" "$dst/SKILL.md"
+    done
+    ;;
+esac
+
+# 6. README: Codex-specific install instructions
+cat > "$OUT/README.md" <<EOF
+# Octave Codex Plugin
+
+> Generated from [octavehq/lfgtm](https://github.com/octavehq/lfgtm). Do not edit directly — changes will be overwritten. File issues and PRs on the upstream repo.
+
+GTM knowledge base integration for OpenAI Codex CLI.
+
+## Install
+
+\`\`\`bash
+codex plugin marketplace add https://github.com/octavehq/lfgtm-codex
+codex plugin install octave@lfgtm
+\`\`\`
+
+## Configure your Octave MCP server
+
+Add your workspace's MCP server (one per workspace):
+
+\`\`\`bash
+codex mcp add octave-acme --url https://mcp.octavehq.com/mcp?ctx=<context>
+\`\`\`
+
+Use any name starting with \`octave-\`. Skills detect the Octave server from available tools.
+
+## Skills
+
+All upstream skills are available, renamed with the \`octave-\` prefix to avoid collisions in the Codex skill namespace:
+
+- \`/octave-research\` (was \`/octave:research\` in Claude Code)
+- \`/octave-library\`, \`/octave-generate\`, \`/octave-battlecard\`, …
+
+See the [upstream README](https://github.com/octavehq/lfgtm#skills) for full descriptions.
+
+## Not included
+
+The upstream plugin ships four subagent personas (\`octave-assistant\`, \`pmm-strategist\`, \`sdr-coach\`, \`revenue-strategist\`). Codex has no subagent concept, so these are not available in this build. Use the corresponding skills directly.
+EOF
+
+# 8. Summary
+echo
+echo "✓ Built Codex artifact at $OUT"
+echo "  skills:    $(find "$OUT/skills" -name SKILL.md | wc -l | tr -d ' ')"
+echo "  workflows: $(find "$OUT/workflows" -name '*.md' | wc -l | tr -d ' ')"


### PR DESCRIPTION
## Summary

- `scripts/build-codex.sh` generates a Codex-compatible plugin from this repo into `build/codex/` (gitignored). Rewrites `plugin.json` and `marketplace.json` to Codex's schema, namespaces skills with `octave-` prefix, rewrites inline `/octave:foo` references, drops `agents/`, and emits a Codex-specific README.
- `.github/workflows/codex-release.yml` publishes the artifact to `octavehq/lfgtm-codex` on tag push.
- Plugin and marketplace descriptions reworded to be AI-assistant-agnostic so the same text renders correctly on both marketplaces without per-platform transformation.

## What this PR does NOT do

- Does not create the downstream `octavehq/lfgtm-codex` repo
- Does not configure the CI secret required to push to it
- Does not verify the generated artifact against a real Codex CLI install

Those are the follow-up steps below.

## Follow-up — required before the workflow can run

### 1. Create the target repo

Create `octavehq/lfgtm-codex` (public, empty):

```bash
gh repo create octavehq/lfgtm-codex --public \
  --description "Octave GTM plugin for OpenAI Codex (generated from octavehq/lfgtm)" \
  --homepage "https://octavehq.com"
```

The workflow force-syncs `build/codex/` into the repo root on every tag push, so the initial state can be empty — the first tag will populate it.

### 2. Create a PAT and add it as a secret

The workflow needs push access to the `lfgtm-codex` repo. On GitHub:

1. Create a **fine-grained PAT** scoped to just `octavehq/lfgtm-codex` with **Contents: Read and write** permission. Expire it in 90 days; calendar a rotation.
2. Add it to **this** repo's secrets as `CODEX_REPO_PAT`:
   ```bash
   gh secret set CODEX_REPO_PAT --repo octavehq/lfgtm-codex  # wrong repo
   gh secret set CODEX_REPO_PAT --repo octavehq/lfgtm        # correct — secret lives here
   ```

### 3. Dry-run before the first tag

Trigger the workflow manually to verify the sync works before tagging a real release:

```bash
gh workflow run codex-release.yml --ref codex-sync
```

Watch the run in Actions; if it pushes a commit to `lfgtm-codex` with the expected tree, you're good. Tags pushed after merge will cut real releases.

### 4. Verify against a real Codex CLI

Install the Codex CLI and test against the generated artifact — the build script uses a few fields that the Codex plugin docs show in examples but don't fully specify:

- `category: "Productivity"` — only example value shown in docs; may not be valid for a GTM plugin
- `source: { source: "local", path: "./" }` — docs show `./plugins/my-plugin` subdir style; self-describing root may or may not work
- No `.mcp.json` shipped — we assume users add MCP via `codex mcp add` (Codex MCP config is TOML, and `.mcp.json` is undocumented)

If any of these fail, we iterate before v1.

## Open design decisions still TBD

- **Subagents.** The 4 agents in `agents/` are dropped from the Codex build (no subagent equivalent). The script has a `CONVERT_AGENTS="skills"` toggle that maps them to skills instead, but invocation semantics differ (skills are user-invoked, agents were model-spawned). Leaving as "drop" for now.
- **Release cadence.** Workflow is gated on tag push (`v*`). If we want the Codex mirror to update on every `main` push instead, we'd swap the trigger.

## Test plan

- [ ] Create `octavehq/lfgtm-codex` repo
- [ ] Create PAT and set `CODEX_REPO_PAT` secret
- [ ] Manually trigger `codex-release.yml` and inspect the resulting `lfgtm-codex` tree
- [ ] Install the Codex CLI and run `codex plugin marketplace add https://github.com/octavehq/lfgtm-codex`
- [ ] Install the plugin and verify at least one skill invokes (e.g. `/octave-workspace`)
- [ ] Add an Octave MCP server via `codex mcp add` and verify `/octave-library list` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)