### PR TITLE
Fix stale STYLE_PRESETS.md pointers and reference headings (v1.9.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "octave",
       "source": "./",
       "description": "Access Octave's GTM knowledge base for positioning, research, content generation, and sales enablement",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "author": {
         "name": "Octave",
         "url": "https://octavehq.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octave",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Octave GTM knowledge base integration for Claude Code and OpenAI Codex — provides bidirectional access to personas, playbooks, messaging, and more. Give Claude and Codex grounded context for your GTM motions.",
   "author": {
     "name": "Octave",

--- a/skills/analyzer/references/conversation-output-template.md
+++ b/skills/analyzer/references/conversation-output-template.md
@@ -1,3 +1,5 @@
+# Conversation Analysis Output Template
+
 ```
 CONVERSATION ANALYSIS
 =====================

--- a/skills/battlecard-doc/SKILL.md
+++ b/skills/battlecard-doc/SKILL.md
@@ -153,7 +153,7 @@ Your choice (number or name, or press Enter for neon-pulse):
 
 If `--style` was provided via flag, skip this prompt and use that preset.
 
-Full CSS variable definitions for each preset are in the deck skill's [STYLE_PRESETS.md](../deck/STYLE_PRESETS.md). Apply the same CSS variable system.
+Full CSS variable definitions for each preset are in the deck skill's [style-presets.md](../deck/references/style-presets.md). Apply the same CSS variable system.
 
 ### Step 4: Generate HTML
 

--- a/skills/battlecard-doc/references/html-architecture.md
+++ b/skills/battlecard-doc/references/html-architecture.md
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=[fonts]&display=swap" rel="stylesheet">
   <style>
-    /* === CSS Variables (from chosen style preset — see STYLE_PRESETS.md) === */
+    /* === CSS Variables (from chosen style preset — see style-presets.md) === */
     :root { /* ... paste chosen preset variables here ... */ }
 
     /* === Reset & Base === */
@@ -173,7 +173,7 @@ For **landscape overview** documents, replace the per-competitor sections with:
 
 1. **Single page, natural scrolling** -- not a slide deck, a vertical reference document
 2. **Sticky sidebar** with section navigation dots (hidden on mobile and print)
-3. **Same CSS variable system as `/octave:deck`** -- apply the preset's `:root` block from STYLE_PRESETS.md
+3. **Same CSS variable system as `/octave:deck`** -- apply the preset's `:root` block from style-presets.md
 4. **Max-width 950px** centered on the page
 5. **Objection handlers as `<details>/<summary>`** -- native HTML expand/collapse, no JS required
 6. **Win/loss scorecard using CSS bars** -- div widths as percentages, green wins, red losses

--- a/skills/brief/SKILL.md
+++ b/skills/brief/SKILL.md
@@ -205,7 +205,7 @@ Does this look good? I can:
 
 ### Step 3: Style Selection
 
-The brief uses the same CSS variable / style preset system as `/octave:deck`. Full preset definitions are in the deck skill's [STYLE_PRESETS.md](../deck/STYLE_PRESETS.md).
+The brief uses the same CSS variable / style preset system as `/octave:deck`. Full preset definitions are in the deck skill's [style-presets.md](../deck/references/style-presets.md).
 
 Briefs default to readability-optimized presets. If `--style` was not provided, ask:
 

--- a/skills/campaign/references/ad-copy-output.md
+++ b/skills/campaign/references/ad-copy-output.md
@@ -1,4 +1,5 @@
-Present as:
+# Ad Copy Variants Output Template
+
 ```
 AD COPY VARIANTS
 ================

--- a/skills/campaign/references/blog-post-output.md
+++ b/skills/campaign/references/blog-post-output.md
@@ -1,4 +1,5 @@
-Present as:
+# Blog Post Output Template
+
 ```
 BLOG POST
 =========

--- a/skills/campaign/references/campaign-plan-output.md
+++ b/skills/campaign/references/campaign-plan-output.md
@@ -1,3 +1,5 @@
+# Campaign Plan Output Template
+
 ```
 CAMPAIGN PLAN: [Campaign Name]
 ==============================

--- a/skills/campaign/references/email-sequence-output.md
+++ b/skills/campaign/references/email-sequence-output.md
@@ -1,4 +1,5 @@
-Present as:
+# Email Sequence Output Template
+
 ```
 EMAIL SEQUENCE (4 emails)
 =========================

--- a/skills/campaign/references/landing-page-output.md
+++ b/skills/campaign/references/landing-page-output.md
@@ -1,4 +1,5 @@
-Present as:
+# Landing Page Copy Output Template
+
 ```
 LANDING PAGE COPY
 =================

--- a/skills/campaign/references/linkedin-output.md
+++ b/skills/campaign/references/linkedin-output.md
@@ -1,4 +1,5 @@
-Present as:
+# LinkedIn Content Output Template
+
 ```
 LINKEDIN CONTENT
 ================

--- a/skills/campaign/references/social-posts-output.md
+++ b/skills/campaign/references/social-posts-output.md
@@ -1,4 +1,5 @@
-Present as:
+# Social Posts Output Template
+
 ```
 SOCIAL POSTS
 ============

--- a/skills/deal-coach/SKILL.md
+++ b/skills/deal-coach/SKILL.md
@@ -475,7 +475,7 @@ Want to:
 
 ##### MS-1: Style Selection
 
-Reference the style preset system from `skills/deck/references/STYLE_PRESETS.md`.
+Reference the style preset system from `skills/deck/references/style-presets.md`.
 
 Each coaching stage has a default style preset:
 

--- a/skills/meeting-prep/SKILL.md
+++ b/skills/meeting-prep/SKILL.md
@@ -253,7 +253,7 @@ Does this look good? I can:
 
 ### Step 3: Style Selection
 
-The battle plan uses the same CSS variable / style preset system as `/octave:deck`. Full preset definitions are in the deck skill's [STYLE_PRESETS.md](../deck/STYLE_PRESETS.md).
+The battle plan uses the same CSS variable / style preset system as `/octave:deck`. Full preset definitions are in the deck skill's [style-presets.md](../deck/references/style-presets.md).
 
 Battle plans default to readability-optimized presets. If `--style` was not provided, ask:
 

--- a/skills/microsite/SKILL.md
+++ b/skills/microsite/SKILL.md
@@ -138,7 +138,7 @@ Use the same tiered brand extraction approach as the deck skill:
 
 **If user chose a style preset:**
 
-Reference the deck skill's [STYLE_PRESETS.md](../deck/STYLE_PRESETS.md). Use the same CSS variable system. Recommended defaults for microsites:
+Reference the deck skill's [style-presets.md](../deck/references/style-presets.md). Use the same CSS variable system. Recommended defaults for microsites:
 
 | Angle | Recommended Preset |
 |-------|--------------------|

--- a/skills/one-pager/SKILL.md
+++ b/skills/one-pager/SKILL.md
@@ -99,7 +99,7 @@ See [tool-reference.md](references/tool-reference.md) for list-vs-search guidanc
 
 ### Step 3: Style Selection
 
-One-pagers use the same 12 style presets and brand extraction system as the deck skill. See [STYLE_PRESETS.md](../deck/STYLE_PRESETS.md) for full CSS variable definitions.
+One-pagers use the same 12 style presets and brand extraction system as the deck skill. See [style-presets.md](../deck/references/style-presets.md) for full CSS variable definitions.
 
 Ask the user:
 

--- a/skills/proposal/SKILL.md
+++ b/skills/proposal/SKILL.md
@@ -173,7 +173,7 @@ Your choice:
 
 See [style-presets.md](references/style-presets.md) for the full list of 12 style presets grouped by theme.
 
-Full CSS variable definitions for each preset are in the deck skill's [STYLE_PRESETS.md](../deck/STYLE_PRESETS.md).
+Full CSS variable definitions for each preset are in the deck skill's [style-presets.md](../deck/references/style-presets.md).
 
 **Brand extraction is encouraged for proposals.** A proposal that carries the customer's or your own brand colors looks significantly more professional and intentional. Follow the same brand discovery flow as `/octave:deck` Step 3 (browser-use > WebFetch > manual fallback).
 

--- a/skills/proposal/references/html-architecture.md
+++ b/skills/proposal/references/html-architecture.md
@@ -1,6 +1,6 @@
 # HTML Architecture
 
-The proposal uses the same CSS variable system as `/octave:deck` (see [STYLE_PRESETS.md](../deck/STYLE_PRESETS.md)) but with a document layout instead of slides.
+The proposal uses the same CSS variable system as `/octave:deck` (see [style-presets.md](../../deck/references/style-presets.md)) but with a document layout instead of slides.
 
 **Core structure:**
 

--- a/skills/win-loss-report/SKILL.md
+++ b/skills/win-loss-report/SKILL.md
@@ -118,12 +118,12 @@ DARK THEMES
   5. executive-dark    -- Charcoal + gold. Premium boardroom.
   6. octave-brand      -- Octave purple on dark navy.
 
-Or provide a number/name from the full preset list (12 options in STYLE_PRESETS.md).
+Or provide a number/name from the full preset list (12 options in style-presets.md).
 
 Your choice (default: paper-minimal):
 ```
 
-Full CSS variable definitions for each preset are in [STYLE_PRESETS.md](../deck/STYLE_PRESETS.md).
+Full CSS variable definitions for each preset are in [style-presets.md](../deck/references/style-presets.md).
 
 ### Step 4: Generate HTML
 


### PR DESCRIPTION
## Summary
Follow-up cleanup from the PR #3 review. Fixes broken cross-skill pointers caused by an earlier `STYLE_PRESETS.md` → `style-presets.md` rename/relocation, and normalizes 8 reference files that were missing a leading heading.

## What changed
- **Casing & path fixes on style-preset references (12 refs, 10 files)** — all now point to `skills/deck/references/style-presets.md`. Covers markdown links (`../deck/STYLE_PRESETS.md` → `../deck/references/style-presets.md`), backtick code references (`skills/deck/references/STYLE_PRESETS.md` → lowercase), and a couple of bare-text mentions. Affected skills: `battlecard-doc`, `brief`, `deal-coach`, `meeting-prep`, `microsite`, `one-pager`, `proposal`, `win-loss-report`.
- **Reference file headings (8 files)** — `analyzer/references/conversation-output-template.md` and the 7 `campaign/references/*-output.md` files previously opened with a raw code fence. Added a `# Title` first line and dropped the orphan `Present as:` lead-in (the SKILL.md pointer already carries that instruction).
- **Version bump** — `1.9.0` → `1.9.1` in `plugin.json` and `marketplace.json`.

## Verification
- [x] `grep STYLE_PRESETS skills/` → no matches
- [x] All reference files now start with a `#` heading
- [x] All 96 intra-skill `references/*.md` markdown links resolve

## Test plan
- [ ] Load a skill that uses the preset reference (e.g. `/octave:meeting-prep`) and confirm the style-selection step still resolves
- [ ] Spot-check a campaign output reference loads cleanly when its pointer is followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)