### PR TITLE
Update MCP tool names and entity docs; bump to v1.9.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "octave",
       "source": "./",
       "description": "Access Octave's GTM knowledge base for positioning, research, content generation, and sales enablement",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "author": {
         "name": "Octave",
         "url": "https://octavehq.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octave",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Octave GTM knowledge base integration for Claude Code and OpenAI Codex — provides bidirectional access to personas, playbooks, messaging, and more. Give Claude and Codex grounded context for your GTM motions.",
   "author": {
     "name": "Octave",

--- a/README.md
+++ b/README.md
@@ -510,14 +510,16 @@ The plugin uses the single Octave MCP server you configure (e.g. `octave-acme`).
 - `create_entity` - Create new entity (AI-generated) - excludes playbooks
 - `update_entity` - Update entity (AI-refined) - excludes playbooks
 - `delete_entity` - Delete any entity type (soft delete)
+- `link_entities_to_offering` - Link or unlink library entities to a specific offering (product/service)
 - `create_playbook` - Create new playbook with dedicated schema
 - `update_playbook` - Update existing playbook
 - `add_value_props` - Add value props to playbook
 - `update_value_props` - Update/archive value props
 
 ### Configuration
-- `list_brand_voices` - List all brand voice configurations
 - `list_writing_styles` - List all writing style configurations
+
+> Brand voices are retrieved via the generic entity tools: `list_all_entities({ entityType: "brand_voice" })` or `list_entities({ entityType: "brand_voice" })`.
 
 ### Resources
 - `list_resources` - List global resources (documents, websites) with filtering
@@ -546,6 +548,12 @@ The plugin uses the single Octave MCP server you configure (e.g. `octave-acme`).
 - `find_crm_records` - Search for CRM records (accounts, contacts, leads, opportunities)
 - `find_crm_activities` - Fetch activities (notes, tasks, calls, emails) for a CRM record
 - `generate_crm_context` - Generate synthesized CRM context summary for a person or company
+
+### Pipeline Analytics
+- `list_pipeline_overview` - Deals grouped by stage with counts, total value, and per-deal detail
+- `list_deal_health` - Assess open deals for stalled stages, expired close dates, single-threading, regressions
+- `get_deal_deep_dive` - Full deal context: stage history, close-date changes, activity, benchmarks, competitive intel
+- `get_pipeline_metrics` - Stage velocity, cycle time, win/loss conversion rates, deal counts
 
 ### Agents
 - `list_agents` - List saved agents

--- a/agents/octave-assistant.md
+++ b/agents/octave-assistant.md
@@ -35,22 +35,28 @@ You have access to the Octave MCP server which provides:
 ### Read Operations
 - `list_all_entities` - Quick list of entities with basic fields (name, oId, type)
 - `list_entities` - Detailed list with pagination, supports filtering by entity type
-- `get_entity` - Get full details for core library entities by oId (persona, product/service, playbook, segment, competitor, use-case, proof-point, reference)
+- `get_entity` - Get full details for any library entity by oId (type is inferred from the oId prefix)
 - `get_playbook` - Get playbook with associated personas and value propositions
 - `list_value_props` - List value propositions for a specific playbook
 - `search_knowledge_base` - Semantic search across all library content (personas, playbooks, products, use cases, etc.)
-- `list_brand_voices` - List all brand voice configurations in the workspace
 - `list_writing_styles` - List all writing style configurations in the workspace
+
+> **Brand voices:** there is no dedicated `list_brand_voices` tool. Use `list_all_entities({ entityType: "brand_voice" })` for discovery or `list_entities({ entityType: "brand_voice" })` for paginated detail.
 
 **Entity Types:**
 - `persona` - Buyer personas (prefix: `pe_`)
-- `product` - Products and services/offerings (prefix: `px_`) - Note: Services are a type of product
+- `product` - Products/offerings (prefix: `px_`)
+- `service` - Services (prefix: `sc_`)
+- `solution` - Workspace-scoped solution offerings (prefix: `sv_`)
 - `playbook` - Messaging playbooks (prefix: `pb_`)
 - `segment` - Market segments (prefix: `sg_`)
 - `use_case` - Use cases (prefix: `uu_`)
 - `competitor` - Competitive intelligence (prefix: `cp_`)
+- `alternative` - Non-direct alternatives customers consider (prefix: `ao_`)
+- `buying_trigger` - Buying triggers / intent signals (prefix: `bq_`)
 - `proof_point` - Case studies and proof points (prefix: `pp_`)
 - `reference` - Reference customers (prefix: `re_`)
+- `hypothesis` - Value propositions (prefix: `hy_`) — managed via playbook value-prop tools rather than `create_entity`
 - `brand_voice` - Brand voice guidelines (prefix: `bv_`)
 - `writing_style` - Writing style and email recipes (prefix: `ws_`)
 
@@ -73,6 +79,7 @@ You have access to the Octave MCP server which provides:
 - `create_entity` - Create any entity type except playbooks (AI-generated based on instructions and sources)
 - `update_entity` - Update any entity type except playbooks (AI-refined based on instructions)
 - `delete_entity` - Delete any entity type (soft delete)
+- `link_entities_to_offering` - Link or unlink library entities (personas, use cases, competitors, proof points, references, etc.) to a specific offering (product or service) by mixed oId arrays
 - `create_playbook` - Create a new playbook with dedicated schema (requires offering selection)
 - `update_playbook` - Update an existing playbook with natural language instructions
 - `add_value_props` - Add new value propositions to a playbook for a specific persona
@@ -108,6 +115,12 @@ You have access to the Octave MCP server which provides:
 - `find_crm_records` - Search for CRM records (accounts, contacts, leads, opportunities) from the connected CRM (Salesforce or HubSpot)
 - `find_crm_activities` - Fetch activities (notes, tasks, calls, emails) associated with a CRM record
 - `generate_crm_context` - Generate a synthesized CRM context summary for a person or company using LLM
+
+### Pipeline Analytics
+- `list_pipeline_overview` - Get pipeline overview with deals grouped by stage (counts, total value per stage, individual deals)
+- `list_deal_health` - Assess health of all open deals (expired close dates, single-threaded deals, stalled stages, activity gaps, regressions)
+- `get_deal_deep_dive` - Get full context for a single deal (stage history, close-date changes, contact info, recent activity, velocity benchmarks, competitive intel)
+- `get_pipeline_metrics` - Pipeline performance metrics (average time per stage, cycle time, win/loss conversion rates, deal counts)
 
 ## Octave Library Taxonomy
 
@@ -186,7 +199,7 @@ Products (use entity type `product`):
 - **Disqualification Questions** - Red flags that indicate poor fit
 
 ### Services
-Services (use entity type `service`, share the `px_` prefix with products):
+Services (use entity type `service`, prefix `sc_`):
 - **Description** - What the service does
 - **Deliverables** - Key deliverables of the service
 - **Competencies** - Key competencies required

--- a/agents/pmm-strategist.md
+++ b/agents/pmm-strategist.md
@@ -41,7 +41,7 @@ You have access to the full Octave MCP server. Your primary tools:
 ### Content Creation
 - `generate_content` - Generate messaging frameworks, positioning, content
 - `generate_email` - Create email sequences grounded in messaging
-- `list_brand_voices` / `list_writing_styles` - Ensure brand consistency
+- `list_all_entities` (entityType: "brand_voice") / `list_writing_styles` - Ensure brand consistency
 
 ### Library Management
 - `create_entity` / `update_entity` - Create and refine library entities

--- a/skills/ads/SKILL.md
+++ b/skills/ads/SKILL.md
@@ -40,7 +40,7 @@ AskUserQuestion({
 
 Generate platform-ready ad campaign plans grounded in your Octave library intelligence. Creates one ad set per persona or ICP, with creative variants generated from real prospect language extracted from calls and emails.
 
-**MCP Server**: This skill requires the Octave MCP server. Look for available MCP tools that match the Octave tool names (e.g., `list_all_entities`, `list_findings`, `search_knowledge_base`, `get_entity`, `list_brand_voices`). The MCP server prefix varies by workspace — it may be `{octave_mcp}__`, `mcp__octave_myworkspace__`, or another name. If multiple Octave-like MCP servers are available and you're unsure which to use, ask the user which workspace to target.
+**MCP Server**: This skill requires the Octave MCP server. Look for available MCP tools that match the Octave tool names (e.g., `list_all_entities`, `list_findings`, `search_knowledge_base`, `get_entity`). The MCP server prefix varies by workspace — it may be `{octave_mcp}__`, `mcp__octave_myworkspace__`, or another name. If multiple Octave-like MCP servers are available and you're unsure which to use, ask the user which workspace to target.
 
 ---
 
@@ -159,7 +159,7 @@ Ask about voice and tone for the creative:
 
 If they choose "Use my Octave brand voice", fetch it in Step 2:
 ```
-→ {octave_mcp}__list_brand_voices()
+→ {octave_mcp}__list_all_entities(entityType: "brand_voice")
 → {octave_mcp}__get_entity(oId: "{brand_voice_oId}")  // fetch full voice guidelines (tone, word choice, style rules)
 ```
 

--- a/skills/campaign/SKILL.md
+++ b/skills/campaign/SKILL.md
@@ -117,7 +117,7 @@ search_knowledge_base({ query: "<campaign topic>", entityTypes: ["proof_point", 
 get_entity({ oId: "<competitor_oId>" })
 
 # Get brand voice
-list_brand_voices()
+list_all_entities(entityType: "brand_voice")
 
 # Get writing style
 list_writing_styles()
@@ -282,7 +282,7 @@ For the full interactive mode selector, use `/octave:generate`.
 - `get_playbook` - Get playbook with value props
 - `list_value_props` - Get value propositions
 - `search_knowledge_base` - Find proof points, references, messaging
-- `list_brand_voices` - Get brand voice for consistency
+- `list_all_entities` (entityType: "brand_voice") - Get brand voice for consistency
 - `list_writing_styles` - Get writing style guidelines
 
 ### Content Generation

--- a/skills/deck/SKILL.md
+++ b/skills/deck/SKILL.md
@@ -753,7 +753,7 @@ for i, slide in enumerate(prs.slides):
 - `generate_email` - Generate email content (for follow-up slides)
 
 ### Brand & Style
-- `list_brand_voices` - Available brand voices in workspace
+- `list_all_entities` (entityType: "brand_voice") - Available brand voices in workspace
 - `list_writing_styles` - Available writing styles in workspace
 
 ## Error Handling

--- a/skills/enablement/SKILL.md
+++ b/skills/enablement/SKILL.md
@@ -109,7 +109,7 @@ search_knowledge_base({
 list_all_entities({ entityType: "competitor" })
 
 # Get brand voice
-list_brand_voices()
+list_all_entities(entityType: "brand_voice")
 ```
 
 ### Step 3: Generate Content Type
@@ -193,7 +193,7 @@ For the full interactive mode selector, use `/octave:generate`.
 
 ### Content Generation
 - `generate_content` - All enablement content types
-- `list_brand_voices` - Brand voice consistency
+- `list_all_entities` (entityType: "brand_voice") - Brand voice consistency
 
 ## Error Handling
 

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -278,7 +278,7 @@ get_playbook({ oId: "<playbook_oId>", includeValueProps: true })
 search_knowledge_base({ query: "<topic>", entityTypes: ["proof_point", "reference"] })
 
 # Get brand voice
-list_brand_voices()
+list_all_entities(entityType: "brand_voice")
 
 # Get competitive positioning if relevant
 search_knowledge_base({ query: "<topic>", entityTypes: ["competitor"] })
@@ -371,7 +371,7 @@ Your choice:
 - `search_knowledge_base` - Find relevant messaging, proof points, personas
 - `get_entity` - Get full entity details (persona, product, competitor)
 - `get_playbook` - Get playbook with value props
-- `list_brand_voices` - Get brand voice for consistency
+- `list_all_entities` (entityType: "brand_voice") - Get brand voice for consistency
 
 ### Octave Generation
 - `generate_email` - Email sequence generation (Octave Default mode)

--- a/skills/launch/SKILL.md
+++ b/skills/launch/SKILL.md
@@ -99,7 +99,7 @@ search_knowledge_base({
 })
 
 # Get brand voice
-list_brand_voices()
+list_all_entities(entityType: "brand_voice")
 ```
 
 ### Step 3: Generate Launch Plan
@@ -248,7 +248,7 @@ For the full interactive mode selector, use `/octave:generate`.
 - `get_entity` - Full entity details
 - `get_playbook` - Playbook with value props
 - `search_knowledge_base` - Proof points, references, competitive intel
-- `list_brand_voices` - Brand voice consistency
+- `list_all_entities` (entityType: "brand_voice") - Brand voice consistency
 
 ### Content Generation
 - `generate_content` - Blog, social, one-pager, FAQ, talking points

--- a/skills/messaging/SKILL.md
+++ b/skills/messaging/SKILL.md
@@ -91,7 +91,7 @@ search_knowledge_base({
 })
 
 # Get brand voice
-list_brand_voices()
+list_all_entities(entityType: "brand_voice")
 
 # Get conversation insights for what resonates
 list_findings({
@@ -167,7 +167,7 @@ update_entity({
 - `get_playbook` - Get playbook with value props
 - `list_value_props` - Get existing value propositions
 - `search_knowledge_base` - Find proof points, references, competitive intel
-- `list_brand_voices` - Brand voice for tone consistency
+- `list_all_entities` (entityType: "brand_voice") - Brand voice for tone consistency
 - `list_findings` - What resonates in real conversations
 
 ### Content Generation

--- a/skills/microsite/SKILL.md
+++ b/skills/microsite/SKILL.md
@@ -329,7 +329,7 @@ Want me to:
 - `generate_content` - Generate positioning or messaging content
 
 ### Brand & Style
-- `list_brand_voices` - Available brand voices in workspace
+- `list_all_entities` (entityType: "brand_voice") - Available brand voices in workspace
 - `list_writing_styles` - Available writing styles in workspace
 
 ## Error Handling

--- a/skills/microsite/references/octave-tool-reference.md
+++ b/skills/microsite/references/octave-tool-reference.md
@@ -10,7 +10,7 @@ Start with enrichment and qualification — this drives the personalization that
 | ICP fit scoring | `qualify_company({ companyDomain })` | Always — matched segment determines which playbook to pull |
 | Matching playbook | `search_knowledge_base({ query: "<industry> <persona>", entityTypes: ["playbook"] })` | Always — messaging, value props, and positioning for their segment |
 | Playbook + value props | `get_playbook({ oId, includeValueProps: true })` | After finding the best-fit playbook — drives the solution section |
-| Brand voice | `list_brand_voices()` | Always — consistent tone across the microsite |
+| Brand voice | `list_all_entities(entityType: "brand_voice")` | Always — consistent tone across the microsite |
 
 ---
 

--- a/skills/one-pager/SKILL.md
+++ b/skills/one-pager/SKILL.md
@@ -246,7 +246,7 @@ Want me to:
 - `generate_content` - Generate positioning or messaging content
 
 ### Brand & Style
-- `list_brand_voices` - Available brand voices in workspace
+- `list_all_entities` (entityType: "brand_voice") - Available brand voices in workspace
 - `list_writing_styles` - Available writing styles in workspace
 
 ## Error Handling

--- a/skills/pmm/SKILL.md
+++ b/skills/pmm/SKILL.md
@@ -173,7 +173,7 @@ Use MCP tools to gather library context:
 
 ```
 # Always get brand voice
-list_brand_voices()
+list_all_entities(entityType: "brand_voice")
 
 # Get product info
 get_entity({ oId: "<product_oId>" })
@@ -257,7 +257,7 @@ Which format?
 Always check for brand voices and apply:
 
 ```
-list_brand_voices()
+list_all_entities(entityType: "brand_voice")
 ```
 
 If multiple voices exist, ask:
@@ -282,7 +282,7 @@ For the full interactive mode selector, use `/octave:generate`.
 ## MCP Tools Used
 
 ### Library Context
-- `list_brand_voices` - Get available brand voices
+- `list_all_entities` (entityType: "brand_voice") - Get available brand voices
 - `list_all_entities` - List products, personas, etc.
 - `get_entity` - Get full entity details
 - `search_knowledge_base` - Find relevant messaging, proof points

--- a/skills/positioning/SKILL.md
+++ b/skills/positioning/SKILL.md
@@ -121,7 +121,7 @@ Every section needs data from the library. Gather it all up front:
 | Playbook + value props | `get_playbook({ oId, includeValueProps: true })` | 1, 2, 4, 5, 8 |
 | Proof points | `list_entities({ entityType: "proof_point" })` | 2, 3, 5 |
 | References | `list_entities({ entityType: "reference" })` | 2, 3 |
-| Brand voice | `list_brand_voices()` | 8 (homepage tone) |
+| Brand voice | `list_all_entities(entityType: "brand_voice")` | 8 (homepage tone) |
 | Competitive positioning | `search_knowledge_base({ query: "<product> differentiation competitive advantage", entityTypes: ["competitor", "playbook"] })` | 2, 3, 6 |
 | What resonates | `list_findings({ query: "value propositions positive reactions resonated", startDate: "<90 days ago>", eventFilters: { sentiments: ["POSITIVE"] } })` | 2, 5 |
 | What falls flat | `list_findings({ query: "objections pushback concerns", startDate: "<90 days ago>", eventFilters: { sentiments: ["NEGATIVE"] } })` | 3, 5 |
@@ -365,7 +365,7 @@ add_value_props({
 
 ### Intelligence & Signals
 - `list_findings` — Conversation findings: what resonates (positive) and what falls flat (negative)
-- `list_brand_voices` — Brand voice for homepage messaging tone
+- `list_all_entities` (entityType: "brand_voice") — Brand voice for homepage messaging tone
 
 ### Content Generation
 - `generate_content` — Synthesize library data into framework structures

--- a/skills/proposal/SKILL.md
+++ b/skills/proposal/SKILL.md
@@ -313,7 +313,7 @@ The proposal is designed with page breaks between sections for clean printing.
 - `generate_content` — Generate positioning or messaging content
 
 ### Brand & Style
-- `list_brand_voices` — Available brand voices in workspace
+- `list_all_entities` (entityType: "brand_voice") — Available brand voices in workspace
 - `list_writing_styles` — Available writing styles in workspace
 
 ## Error Handling

--- a/skills/repurpose/SKILL.md
+++ b/skills/repurpose/SKILL.md
@@ -127,7 +127,7 @@ search_knowledge_base({
 })
 
 # Get brand voice if adjusting tone
-list_brand_voices()
+list_all_entities(entityType: "brand_voice")
 
 # Get writing style if specified
 list_writing_styles()
@@ -154,7 +154,7 @@ search_knowledge_base({
 **For Format/Channel Changes:**
 ```
 # Get brand voice guidelines
-list_brand_voices()
+list_all_entities(entityType: "brand_voice")
 
 # Get writing style for target format
 search_knowledge_base({
@@ -290,7 +290,7 @@ See [common-scenarios.md](references/common-scenarios.md) for the four common re
 
 ### Read Operations
 - `list_all_entities` - Get available personas and segments
-- `list_brand_voices` - Get available brand voice configurations
+- `list_all_entities` (entityType: "brand_voice") - Get available brand voice configurations
 - `list_writing_styles` - Get available writing style configurations
 - `get_entity` - Get full details for persona and segment entities by oId
 - `get_playbook` - Get messaging guidance and value props

--- a/skills/workspace/SKILL.md
+++ b/skills/workspace/SKILL.md
@@ -9,20 +9,26 @@ Show which Octave MCP server is connected.
 
 ## Instructions
 
-1. **Find the Octave MCP server** by looking at your available tools for ones like `verify_connection`, `get_entity`, `list_all_entities`
+1. **Find the Octave MCP server** by looking at your available tools for ones like `verify_connection`, `get_entity`, `list_all_entities`.
 
-2. **Show the server name** (e.g. `octave-acme`):
+2. **Call `verify_connection`** to confirm the API key is valid and to fetch the authoritative workspace/organization names. This is the canonical probe.
+
+3. **Show the server name and workspace info** from the `verify_connection` response:
 ```
    Current Octave Workspace
    ========================
-   MCP Server: <mcpServerName>
+   MCP Server:   <mcpServerName>
+   Workspace:    <workspaceName> (<workspaceOId>)
+   Organization: <organizationSlug> (<organizationOId>)
 ```
 
-3. **If no Octave tools found:**
+4. **If no Octave tools found:**
 ```
    No Octave MCP server detected.
 
    Add one with: claude mcp add octave-<workspaceName> --transport http <url>
 ```
 
-4. **If user asks to switch:** Explain they need to configure a different MCP server in their Claude settings.
+5. **If `verify_connection` fails** (invalid API key, network error): surface the error message and suggest re-running `claude mcp add` with a fresh API key.
+
+6. **If user asks to switch:** Explain they need to configure a different MCP server in their Claude settings.

--- a/workflows/content-sprint.workflow.md
+++ b/workflows/content-sprint.workflow.md
@@ -39,8 +39,8 @@ Build the messaging angle for this content sprint.
 
 Ensure content consistency.
 
-- tool: list_brand_voices
-- params: {}
+- tool: list_all_entities
+- params: { entityType: "brand_voice" }
 - save_as: brand_voices
 - description: Get brand voice guidelines for content generation
 

--- a/workflows/positioning-exercise.workflow.md
+++ b/workflows/positioning-exercise.workflow.md
@@ -121,7 +121,8 @@ Deep data pull for the selected product. All data gathered here feeds into all 8
 - save_as: positive_findings
 - description: What resonates in real conversations — grounds Anchors and Awareness Funnel
 
-- tool: list_brand_voices
+- tool: list_all_entities
+- params: { entityType: "brand_voice" }
 - save_as: brand_voices
 - description: Brand voice for Homepage Messaging tone consistency
 


### PR DESCRIPTION
## Summary
- Replaces the deprecated `list_brand_voices` MCP tool with `list_all_entities(entityType: "brand_voice")` across 15 skills, 2 agents, 2 workflows, and the README.
- Documents new entity types (`service` → `sc_`, `solution` → `sv_`, `alternative` → `ao_`, `buying_trigger` → `bq_`, `hypothesis` → `hy_`), the `link_entities_to_offering` tool, and the new Pipeline Analytics tools (`list_pipeline_overview`, `list_deal_health`, `get_deal_deep_dive`, `get_pipeline_metrics`).
- Hardens `/octave:workspace` to probe the connection via `verify_connection` and surface workspace/organization identity.
- Bumps plugin + marketplace version to **v1.9.2** (patch — reference/documentation updates only, no new skills).

## Why
The Octave MCP server consolidated brand voices under the generic entity tools and introduced additional entity types and pipeline analytics tools. Skill and agent references were pointing at the old tool surface, which would cause broken tool calls at runtime.

## Test plan
- [ ] Verify plugin loads cleanly at v1.9.2 (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`).
- [ ] Spot-check one skill per category (ads, campaign, microsite, workspace) to confirm brand voice retrieval works via `list_all_entities(entityType: "brand_voice")`.
- [ ] Run `/octave:workspace` and confirm it calls `verify_connection` and displays workspace + organization names.
- [ ] Confirm the content-sprint and positioning-exercise workflows execute the updated `list_all_entities` step without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)