### PR TITLE
Document link_entities_to_offering MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ The plugin uses the single Octave MCP server you configure (e.g. `octave-acme`).
 - `update_playbook` - Update existing playbook
 - `add_value_props` - Add value props to playbook
 - `update_value_props` - Update/archive value props
+- `link_entities_to_offering` - Link/unlink personas, use cases, references, competitors, alternatives, buying triggers, proof points, segments to a product or service
 
 ### Configuration
 - `list_brand_voices` - List all brand voice configurations


### PR DESCRIPTION
## Summary
- Adds the new `link_entities_to_offering` MCP tool to the Library Write section of the README catalog.
- Links/unlinks personas, use cases, references, competitors, alternatives, buying triggers, proof points, and segments to a product or service offering.

## Test plan
- [ ] README Library Write section renders with the new bullet
- [ ] Tool name matches what's registered in `octave-app/src/server/mcp/tools/library/link-entities-to-offering.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)