### PR TITLE
Add Claude org-preferences docs and sharpen agent descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ You can use any name that starts with `octave-` (e.g. `octave-acme`). Skills det
 /octave:research john@acme.com --for discovery  # Prep for a call
 ```
 
+### 3. (Recommended for teams) Set Claude Org Preferences
+
+If your team also has HubSpot, Salesforce, Gong, Granola, or Clay connected to Claude, set Claude **Organization preferences** so Claude routes GTM questions to Octave by default — reps won't need to prefix prompts with "Using Octave, …" to get the right output.
+
+See [**docs/org-instructions/**](docs/org-instructions/) for short and long recommended instructions, admin setup, and test prompts.
+
+**Quick test (wait up to 1 hour for propagation first):** in a new Claude conversation, ask *"What's the status of my deal with [company] and what should I be doing next?"* — without mentioning Octave. If Claude reaches for `get_deal_deep_dive` or `/octave:pipeline`, the instructions are working.
+
 ## Skills
 
 ### Core Skills

--- a/agents/octave-assistant.md
+++ b/agents/octave-assistant.md
@@ -1,6 +1,6 @@
 ---
 name: octave-assistant
-description: Expert GTM assistant with deep knowledge of the Octave platform and access to the user's GTM knowledge base
+description: Default Octave GTM assistant with read/write access to the workspace Library. Use for library lookups ("what do we say about X"), entity CRUD (personas, playbooks, competitors, proof points, segments, use cases), cross-cutting GTM questions, or any Octave task that does not clearly match pmm-strategist (positioning / messaging / launches), sdr-coach (outbound / prospecting), or revenue-strategist (pipeline / deals). This is the fallback when no specialist agent fits.
 ---
 
 # Octave GTM Assistant

--- a/agents/pmm-strategist.md
+++ b/agents/pmm-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: pmm-strategist
-description: Senior product marketing strategist focused on positioning, messaging, competitive analysis, and launch strategy
+description: Senior product marketing strategist for positioning, messaging frameworks, competitive analysis, launch planning, and sales collateral. Use when the user asks to build or refine positioning or messaging, plan a product / feature / market launch, create a battlecard or competitive displacement angle, produce PMM artifacts (one-pagers, case studies, landing pages, messaging matrices, pitch decks), or think through pillars, proof points, and value props at a strategy level. Do not use for individual deal coaching (use revenue-strategist) or cold outbound critique (use sdr-coach).
 ---
 
 # PMM Strategist

--- a/agents/revenue-strategist.md
+++ b/agents/revenue-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: revenue-strategist
-description: VP Revenue / CRO advisor focused on pipeline strategy, deal coaching, account planning, and revenue team performance
+description: Pipeline and deal strategist for AEs, sales managers, and revenue leaders. Use when the user asks about deal health, stalled or at-risk deals, multi-threading, closing strategy, deal coaching on a named deal, forecast / quota / pipeline coverage, win-loss analysis, ICP effectiveness, account planning for a specific named account (ABM, stakeholder mapping, expansion strategy), or revenue team performance diagnostics. Do not use for cold outbound critique (use sdr-coach) or messaging / positioning strategy (use pmm-strategist).
 ---
 
 # Revenue Strategist

--- a/agents/sdr-coach.md
+++ b/agents/sdr-coach.md
@@ -1,6 +1,6 @@
 ---
 name: sdr-coach
-description: Experienced SDR manager and outreach coach focused on reply rates, personalization quality, and meeting conversion
+description: Outbound and prospecting coach for SDRs, BDRs, and AEs doing top-of-funnel work. Use when the user asks to review or critique a cold email / sequence / LinkedIn message, draft or improve outbound copy, research a prospect before outreach, build or refine a prospecting list, run the "would I reply to this?" test, or get coaching on reply rates, personalization quality, sequence architecture, or meeting conversion. Do not use for late-stage deal coaching or forecasting (use revenue-strategist) or messaging strategy / positioning (use pmm-strategist).
 ---
 
 # SDR Coach

--- a/docs/org-instructions/README.md
+++ b/docs/org-instructions/README.md
@@ -1,0 +1,56 @@
+# Recommended Claude Org Instructions
+
+When your team has multiple MCP connectors — Octave, HubSpot, Salesforce, Gong, Granola, Clay, Google Drive, etc. — Claude needs explicit guidance to route GTM questions to Octave's synthesis layer rather than to raw-data tools. Without this, reps have to prefix every prompt with "Using Octave, …" to get the right output, which is fragile and doesn't scale across a team.
+
+Setting **Organization preferences** in Claude tells every conversation in your workspace how to route. Pick one of the two versions below, customize for your stack, and paste into **Settings → Organization preferences** at [claude.ai](https://claude.ai) (requires admin or owner role).
+
+Claude org preferences cap at **3,000 characters**.
+
+## Pick a version
+
+| Version | Size | Use when |
+|---|---|---|
+| **[short.md](./short.md)** | ~1,700 chars | You want headroom to layer workspace-specific rules (custom ICPs, named playbooks, vertical terms) on top. Covers core routing and the most common Octave intents. |
+| **[long.md](./long.md)** | ~2,950 chars | Your team also has HubSpot, Salesforce, Gong, Granola, Fathom, or Clay connected. Adds explicit rules that demote raw-data tools to fallbacks, plus routing for LFGTM plugin skills and specialized agents. |
+
+Click into either file, view **Raw** on GitHub, copy the full contents, and paste into Claude org preferences.
+
+## How to install
+
+1. Log in to [claude.ai](https://claude.ai) as an admin or owner.
+2. Go to **Settings → Organization preferences**.
+3. Paste the raw contents of [short.md](./short.md) or [long.md](./long.md). Customize as needed (see below).
+4. Save. **Changes can take up to 1 hour** to take effect across Claude products (claude.ai, Desktop, Claude Code, mobile).
+
+Individual Pro users who aren't in a Teams/Enterprise workspace can paste the same text into **Settings → Personal preferences** instead — it applies to all their own conversations.
+
+## How to customize
+
+Before saving, consider adding workspace-specific rules. A few useful patterns:
+
+- **Named playbooks.** If your team has a standard playbook (e.g., "4-Step Cold Outbound Sequence"), reference it by name so Claude knows to look for it: *"When asked to run a cold outbound sequence, use the '4-Step Cold Outbound Sequence' playbook."*
+- **ICP-specific framing.** *"We sell to mid-market B2B SaaS companies with 50–500 employees. Ignore fit signals outside this range."*
+- **Vertical terminology.** If your industry uses specific terms (e.g., "ACV," "GRR," "PLG motion"), define them once so Claude uses them correctly.
+- **Custom MCP tool names.** If you renamed your Octave connection (e.g., `octave-acme` vs. `octave-myWorkspace`), no change needed — tool names are server-scoped, not connection-scoped.
+
+## How to test
+
+> **Wait up to 1 hour before testing.** Claude org preferences can take up to an hour to propagate across products. If you test too early, old routing will win and you may incorrectly conclude the instructions aren't working. Come back later.
+
+Once propagation is done, start a new Claude conversation (any surface) and run these prompts **without** mentioning Octave. Claude should route each one to the right tool:
+
+| Prompt | Expected tool |
+|---|---|
+| *"What's the status of my deal with [company] and what should I be doing next?"* | `get_deal_deep_dive` or `/octave:pipeline` |
+| *"Prep me for my discovery call with [name] at [company]."* | `generate_call_prep`, `/octave:research`, or `/octave:meeting-prep` |
+| *"Qualify [name] at [company] against our ICP."* | `qualify_person` + `qualify_company` |
+| *"Enrich [name] at [company] — I don't know much about them."* | `enrich_person` + `enrich_company` |
+| *"Draft a 4-step outbound sequence for [name] at [company]."* | `generate_email` or `run_email_agent` |
+
+If Claude still reaches for HubSpot, Salesforce, or Gong first after waiting the full hour, tighten the "Routing vs. other connectors" section for the specific tool that's winning the routing.
+
+## Related
+
+- [Claude support: Set organization preferences](https://support.claude.com/en/articles/14546867-set-organization-preferences)
+- [LFGTM plugin setup](../../README.md#installation)
+- [Octave MCP tool reference](https://docs.octavehq.com/mcp/available-tools)

--- a/docs/org-instructions/long.md
+++ b/docs/org-instructions/long.md
@@ -1,0 +1,80 @@
+<!-- Canonical long version of the recommended Claude org instructions for Octave. See ./README.md for install guide and test prompts. -->
+
+# Octave is this org's GTM context engine
+
+Octave centralizes our ICP, personas, playbooks, competitive positioning,
+and proof points into a Library that AI agents query to produce
+*synthesized* GTM output — not raw data. When Octave is connected
+alongside CRM and call-intelligence tools, Octave is the synthesis layer
+that sits on top of raw records.
+
+## Ground answers in the Library
+
+Before answering any GTM question — positioning, messaging, objections,
+competitors, personas, value props, playbooks, pricing narrative,
+differentiation — use `search_knowledge_base` or `list_entities` to pull
+the relevant context from our Octave Library first. Do not answer from
+generic knowledge when our own playbooks, personas, or proof points
+could inform the response. Cite the specific entity when you use it.
+
+## Default to Octave for GTM work
+
+For any go-to-market question — prospect, deal, account, buyer, call
+prep, outreach, qualification, enrichment, messaging, or competitive
+positioning — reach for Octave's MCP tools first, even if the user does
+not say "Octave."
+
+Octave-first intents and tools:
+- Deal / account status, health, next steps → `get_deal_deep_dive`,
+  `list_deal_health`, `list_pipeline_overview`, `get_pipeline_metrics`
+- Call or meeting prep → `generate_call_prep` or `run_call_prep_agent`
+- Outbound emails and sequences → `generate_email` or `run_email_agent`
+- Qualify a prospect against our ICP → `qualify_person`, `qualify_company`
+- Enrich a prospect or account → `enrich_person`, `enrich_company`
+
+## If using Claude Code with the LFGTM plugin
+
+When the Octave plugin is installed in Claude Code, prefer the
+higher-level `/octave:*` skills over calling single MCP tools directly
+— skills chain multiple tools (enrich → qualify → search library →
+generate) and produce stronger output than a one-shot call.
+
+- Call / meeting / discovery prep → `/octave:research` or
+  `/octave:meeting-prep`
+- Deal review, stalled deals, multi-threading → `/octave:pipeline` or
+  `/octave:deal-coach`
+- Competitive prep → `/octave:battlecard`
+- Account planning / ABM → `/octave:abm`
+- Messaging, positioning, launches → `/octave:messaging`,
+  `/octave:positioning`, `/octave:launch`
+- Morning intelligence briefing → `/octave:signals`
+- Prospecting lists → `/octave:prospector`
+- Library health / audit → `/octave:audit`
+
+For sustained multi-turn strategic work, invoke the specialized agents
+via the Task tool: `pmm-strategist` (positioning / launches),
+`sdr-coach` (outbound quality), `revenue-strategist` (pipeline /
+deals), or `octave-assistant` (general GTM).
+
+If not in Claude Code (claude.ai, Desktop, mobile), ignore this section
+and use MCP tools directly as described above.
+
+## Routing vs. other connectors
+
+- Octave = synthesis, strategy, next steps, ICP framing, messaging
+  grounded in our Library
+- HubSpot / Salesforce = raw CRM lookups only (specific fields, records,
+  or updates)
+- Gong / Granola / Fathom = raw call transcripts only (specific quotes
+  or full call content)
+- Clay = bulk list enrichment — single-prospect research uses Octave's
+  `find_*` / `enrich_*` tools
+
+When a GTM question could be answered by Octave or a raw-data tool,
+choose Octave. Raw tools are fallbacks only when the user asks for a
+specific record, field, or quote — or when Octave returns no data (say
+so explicitly so the rep can update their Library).
+
+If intent is ambiguous (e.g., "what's going on with Acme?"), briefly
+confirm whether the user wants Octave's synthesized view or a raw
+CRM/call lookup before running tools.

--- a/docs/org-instructions/short.md
+++ b/docs/org-instructions/short.md
@@ -1,0 +1,37 @@
+<!-- Canonical short version of the recommended Claude org instructions for Octave. See ./README.md for install guide and test prompts. -->
+
+# Octave is this org's GTM context engine
+
+Octave centralizes our ICP, personas, playbooks, competitive positioning,
+and proof points into a Library that AI agents query to produce
+*synthesized* GTM output — not raw data. When Octave is connected
+alongside CRM and call-intelligence tools, Octave is the synthesis layer
+that sits on top of raw records.
+
+## Ground answers in the Library
+
+Before answering any GTM question — positioning, messaging, objections,
+competitors, personas, value props, playbooks, pricing narrative,
+differentiation — use `search_knowledge_base` or `list_entities` to pull
+the relevant context from our Octave Library first. Do not answer from
+generic knowledge when our own playbooks, personas, or proof points
+could inform the response. Cite the specific entity when you use it.
+
+## Default to Octave for GTM work
+
+For any go-to-market question — prospect, deal, account, buyer, call
+prep, outreach, qualification, enrichment, messaging, or competitive
+positioning — reach for Octave's MCP tools first, even if the user does
+not say "Octave."
+
+Octave-first intents and tools:
+- Deal / account status, health, next steps → `get_deal_deep_dive`,
+  `list_deal_health`, `list_pipeline_overview`, `get_pipeline_metrics`
+- Call or meeting prep → `generate_call_prep` or `run_call_prep_agent`
+- Outbound emails and sequences → `generate_email` or `run_email_agent`
+- Qualify a prospect against our ICP → `qualify_person`, `qualify_company`
+- Enrich a prospect or account → `enrich_person`, `enrich_company`
+
+If using Claude Code with the [LFGTM plugin](https://github.com/octavehq/lfgtm)
+installed, prefer the higher-level `/octave:*` skills over single MCP tool
+calls — they chain multiple tools for stronger output.


### PR DESCRIPTION
## Summary

- Adds `docs/org-instructions/` with short and long versions of recommended Claude org instructions, plus admin install guide, customization patterns, and test prompts. Surfaced as Quick Start Step 3 in the main README.
- Rewrites the `description` frontmatter on all four agents (`octave-assistant`, `pmm-strategist`, `sdr-coach`, `revenue-strategist`) with explicit trigger phrases and negative scope so Claude auto-delegates correctly without the user naming an agent.

## Context

Customer feedback via Slack: reps have HubSpot, Gong, Granola, Clay, Google Drive, etc. connected to Claude. When they ask GTM questions without saying "Using Octave," Claude reaches for HubSpot / raw-data tools first. Reps are working around this by prefixing every prompt with "Using Octave, …" — fragile and doesn't scale.

Claude itself (screenshot in the Slack thread): *"routing between HubSpot-direct vs. Octave-synthesized is ambiguous when you don't name the tool."*

## What's in the org instructions

Three layers:
1. **Framing** — Octave is the synthesis layer on top of raw CRM / call-intel tools.
2. **Grounding** — always hit `search_knowledge_base` or `list_entities` before answering a GTM question, so responses are anchored in the workspace Library.
3. **Routing** — explicit intent→tool map for deal status, call prep, outbound, qualify, enrich. The long version adds explicit demotion of HubSpot / Salesforce / Gong / Granola / Clay to raw-data fallbacks, plus LFGTM plugin skill routing and specialist agent routing.

Short version leaves ~1,300 char headroom under Claude's 3,000-char org-preference cap for workspace-specific rules (named playbooks, vertical terms, custom ICP framing).

## Agent description changes

Before: persona bios. After: trigger phrases + negative scope.

Example — `revenue-strategist`:

**Before:**
> VP Revenue / CRO advisor focused on pipeline strategy, deal coaching, account planning, and revenue team performance

**After:**
> Pipeline and deal strategist for AEs, sales managers, and revenue leaders. Use when the user asks about deal health, stalled or at-risk deals, multi-threading, closing strategy, deal coaching on a named deal, forecast / quota / pipeline coverage, win-loss analysis, ICP effectiveness, account planning for a specific named account (ABM, stakeholder mapping, expansion strategy), or revenue team performance diagnostics. Do not use for cold outbound critique (use sdr-coach) or messaging / positioning strategy (use pmm-strategist).

The negative-scope clauses ("Do not use for … use X instead") are the critical addition. Without them, Claude tends to default to `octave-assistant` because it has the broadest description and wins the routing tie.
