### PR TITLE
Update HTML templates: fixed-canvas decks, PDF/deploy export, brand discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "octave",
       "source": "./",
       "description": "Access Octave's GTM knowledge base for positioning, research, content generation, and sales enablement",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "author": {
         "name": "Octave",
         "url": "https://octavehq.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octave",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Octave GTM knowledge base integration for Claude Code and OpenAI Codex — provides bidirectional access to personas, Motions, messaging, and more. Give Claude and Codex grounded context for your GTM motions.",
   "author": {
     "name": "Octave",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# deploy.sh — Deploy a slide deck to Vercel for instant sharing
+#
+# Usage:
+#   bash scripts/deploy.sh <path-to-slide-folder-or-html>
+#
+# Examples:
+#   bash scripts/deploy.sh ./my-pitch-deck/
+#   bash scripts/deploy.sh ./presentation.html
+#
+# What this does:
+#   1. Checks if Vercel CLI is installed (installs if not)
+#   2. Checks if user is logged in (guides through login if not)
+#   3. Deploys the slide deck to a public URL
+#   4. Prints the live URL
+#
+# The deployed URL is permanent and works on any device (mobile, tablet, desktop).
+# No server to maintain — Vercel hosts it for free.
+set -euo pipefail
+
+# ─── Colors ────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${CYAN}ℹ${NC} $*"; }
+ok()    { echo -e "${GREEN}✓${NC} $*"; }
+warn()  { echo -e "${YELLOW}⚠${NC} $*"; }
+err()   { echo -e "${RED}✗${NC} $*" >&2; }
+
+# ─── Input validation ─────────────────────────────────────
+
+if [[ $# -lt 1 ]]; then
+    err "Usage: bash scripts/deploy.sh <path-to-slide-folder-or-html>"
+    err ""
+    err "Examples:"
+    err "  bash scripts/deploy.sh ./my-pitch-deck/"
+    err "  bash scripts/deploy.sh ./presentation.html"
+    exit 1
+fi
+
+INPUT="$1"
+
+# If input is a single HTML file, create a temp directory with it as index.html
+if [[ -f "$INPUT" && "$INPUT" == *.html ]]; then
+    DEPLOY_DIR=$(mktemp -d)
+    cp "$INPUT" "$DEPLOY_DIR/index.html"
+    PARENT_DIR=$(dirname "$INPUT")
+
+    # Parse the HTML for local file references (src="...", url('...'), href="...")
+    # and copy any referenced local files into the deploy directory
+    grep -oE '(src|href|url\()["'"'"']?[^"'"'"'>)]+' "$INPUT" 2>/dev/null | \
+        sed "s/^src=//; s/^href=//; s/^url(//; s/[\"']//g" | \
+        grep -v '^http' | grep -v '^data:' | grep -v '^#' | grep -v '^/' | \
+        sort -u | while read -r ref; do
+            # Resolve the reference relative to the HTML file's directory
+            SOURCE_FILE="$PARENT_DIR/$ref"
+            if [[ -e "$SOURCE_FILE" ]]; then
+                # Preserve directory structure for nested paths (e.g., assets/img.png)
+                TARGET_DIR="$DEPLOY_DIR/$(dirname "$ref")"
+                mkdir -p "$TARGET_DIR"
+                cp -r "$SOURCE_FILE" "$TARGET_DIR/"
+            fi
+        done
+
+    # Also copy any assets/ folder if it exists (common convention)
+    if [[ -d "$PARENT_DIR/assets" ]]; then
+        cp -r "$PARENT_DIR/assets" "$DEPLOY_DIR/assets" 2>/dev/null || true
+    fi
+
+    CLEANUP_TEMP=true
+    info "Single HTML file detected — preparing for deployment..."
+elif [[ -d "$INPUT" ]]; then
+    # Verify the folder has an index.html
+    if [[ ! -f "$INPUT/index.html" ]]; then
+        err "Folder '$INPUT' does not contain an index.html file."
+        err "Make sure your presentation folder has an index.html."
+        exit 1
+    fi
+    DEPLOY_DIR="$INPUT"
+    CLEANUP_TEMP=false
+else
+    err "'$INPUT' is not a valid HTML file or directory."
+    exit 1
+fi
+
+# ─── Step 1: Check for Vercel CLI ─────────────────────────
+
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║       Deploy Slides to Vercel         ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════╝${NC}"
+echo ""
+
+if ! command -v npx &>/dev/null; then
+    err "Node.js is required but not installed."
+    err ""
+    err "Install Node.js:"
+    err "  macOS:   brew install node"
+    err "  or visit https://nodejs.org and download the installer"
+    exit 1
+fi
+
+info "Checking Vercel CLI..."
+
+# Check if vercel is available (either globally or via npx)
+if command -v vercel &>/dev/null; then
+    VERCEL_CMD="vercel"
+    ok "Vercel CLI found"
+elif npx --yes vercel --version &>/dev/null 2>&1; then
+    VERCEL_CMD="npx --yes vercel"
+    ok "Vercel CLI available via npx"
+else
+    info "Installing Vercel CLI..."
+    npm install -g vercel
+    VERCEL_CMD="vercel"
+    ok "Vercel CLI installed"
+fi
+
+# ─── Step 2: Check login status ───────────────────────────
+
+echo ""
+info "Checking Vercel login status..."
+
+# Try to check if logged in by running whoami
+if ! $VERCEL_CMD whoami &>/dev/null 2>&1; then
+    echo ""
+    warn "You're not logged in to Vercel yet."
+    echo ""
+    echo -e "${BOLD}To log in, run this command and follow the prompts:${NC}"
+    echo ""
+    echo "    vercel login"
+    echo ""
+    echo "If you don't have a Vercel account yet:"
+    echo "  1. Go to https://vercel.com/signup"
+    echo "  2. Sign up with GitHub, GitLab, email, or any method"
+    echo "  3. Come back here and run: vercel login"
+    echo "  4. Then re-run this deploy script"
+    echo ""
+
+    # Try interactive login
+    echo -e "${YELLOW}Attempting interactive login now...${NC}"
+    echo ""
+    $VERCEL_CMD login || {
+        err "Login failed. Please run 'vercel login' manually and try again."
+        [[ "$CLEANUP_TEMP" == "true" ]] && rm -rf "$DEPLOY_DIR"
+        exit 1
+    }
+    echo ""
+    ok "Logged in to Vercel!"
+fi
+
+VERCEL_USER=$($VERCEL_CMD whoami 2>/dev/null || echo "unknown")
+ok "Logged in as: $VERCEL_USER"
+
+# ─── Step 3: Deploy ───────────────────────────────────────
+
+echo ""
+info "Deploying slides..."
+echo ""
+
+# Deploy with sensible defaults:
+#   --yes: skip confirmation prompts
+#   --prod: deploy to production URL (not preview)
+#   --name: use the folder name as the project name
+DECK_NAME=$(basename "$DEPLOY_DIR")
+# If we used a temp dir, use the original filename without .html
+if [[ "$CLEANUP_TEMP" == "true" ]]; then
+    DECK_NAME=$(basename "$INPUT" .html)
+fi
+
+# Sanitize project name for Vercel:
+# - lowercase, replace spaces/special chars with hyphens
+# - collapse multiple hyphens, trim to 100 chars
+DECK_NAME=$(echo "$DECK_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-100)
+
+# Vercel uses the directory name as the project name, so rename the deploy
+# directory to the sanitized deck name (avoids deprecated --name flag)
+if [[ "$CLEANUP_TEMP" == "true" ]]; then
+    RENAMED_DIR="$(dirname "$DEPLOY_DIR")/$DECK_NAME"
+    mv "$DEPLOY_DIR" "$RENAMED_DIR"
+    DEPLOY_DIR="$RENAMED_DIR"
+fi
+
+DEPLOY_OUTPUT=$($VERCEL_CMD deploy "$DEPLOY_DIR" --yes --prod 2>&1) || {
+    err "Deployment failed:"
+    echo "$DEPLOY_OUTPUT"
+    [[ "$CLEANUP_TEMP" == "true" ]] && rm -rf "$DEPLOY_DIR"
+    exit 1
+}
+
+# Extract the URL from output
+DEPLOY_URL=$(echo "$DEPLOY_OUTPUT" | grep -o 'https://[^ ]*' | tail -1)
+
+# ─── Step 4: Success ──────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}════════════════════════════════════════${NC}"
+ok "Slides deployed successfully!"
+echo ""
+echo -e "  ${BOLD}Live URL:${NC}  $DEPLOY_URL"
+echo ""
+echo "  This URL works on any device — phones, tablets, laptops."
+echo "  Share it via Slack, email, text, or anywhere."
+echo ""
+echo -e "  ${CYAN}Tip:${NC} To take it down later, visit https://vercel.com/dashboard"
+echo -e "       and delete the project '${DECK_NAME}'."
+echo -e "${BOLD}════════════════════════════════════════${NC}"
+echo ""
+
+# ─── Cleanup ──────────────────────────────────────────────
+
+if [[ "$CLEANUP_TEMP" == "true" ]]; then
+    rm -rf "$DEPLOY_DIR"
+fi

--- a/scripts/export-pdf.sh
+++ b/scripts/export-pdf.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+# export-pdf.sh — Export an HTML presentation to PDF
+#
+# Usage:
+#   bash scripts/export-pdf.sh <path-to-html> [output.pdf]
+#
+# Examples:
+#   bash scripts/export-pdf.sh ./my-deck/index.html
+#   bash scripts/export-pdf.sh ./presentation.html ./presentation.pdf
+#
+# What this does:
+#   1. Starts a local server to serve the HTML (fonts and assets need HTTP)
+#   2. Uses Playwright to screenshot each slide at 1920x1080
+#   3. Combines all screenshots into a single PDF
+#   4. Cleans up the server and temp files
+#
+# The PDF preserves colors, fonts, and layout — but not animations.
+# Perfect for email attachments, printing, or embedding in documents.
+set -euo pipefail
+
+# ─── Colors ────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${CYAN}ℹ${NC} $*"; }
+ok()    { echo -e "${GREEN}✓${NC} $*"; }
+warn()  { echo -e "${YELLOW}⚠${NC} $*"; }
+err()   { echo -e "${RED}✗${NC} $*" >&2; }
+
+# ─── Parse flags ──────────────────────────────────────────
+
+# Default resolution: 1920x1080 (full HD, ~1-2MB per slide)
+# Compact resolution: 1280x720 (HD, ~50-70% smaller files)
+VIEWPORT_W=1920
+VIEWPORT_H=1080
+COMPACT=false
+
+POSITIONAL=()
+for arg in "$@"; do
+    case $arg in
+        --compact)
+            COMPACT=true
+            VIEWPORT_W=1280
+            VIEWPORT_H=720
+            ;;
+        *)
+            POSITIONAL+=("$arg")
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+
+# ─── Input validation ─────────────────────────────────────
+
+if [[ $# -lt 1 ]]; then
+    err "Usage: bash scripts/export-pdf.sh <path-to-html> [output.pdf] [--compact]"
+    err ""
+    err "Examples:"
+    err "  bash scripts/export-pdf.sh ./my-deck/index.html"
+    err "  bash scripts/export-pdf.sh ./presentation.html ./slides.pdf"
+    err "  bash scripts/export-pdf.sh ./presentation.html --compact   # smaller file size"
+    exit 1
+fi
+
+INPUT_HTML="$1"
+if [[ ! -f "$INPUT_HTML" ]]; then
+    err "File not found: $INPUT_HTML"
+    exit 1
+fi
+
+# Resolve to absolute path
+INPUT_HTML=$(cd "$(dirname "$INPUT_HTML")" && pwd)/$(basename "$INPUT_HTML")
+
+# Output PDF path: use second argument or derive from input name
+if [[ $# -ge 2 ]]; then
+    OUTPUT_PDF="$2"
+else
+    OUTPUT_PDF="$(dirname "$INPUT_HTML")/$(basename "$INPUT_HTML" .html).pdf"
+fi
+
+# Resolve output to absolute path
+OUTPUT_DIR=$(dirname "$OUTPUT_PDF")
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_PDF="$OUTPUT_DIR/$(basename "$OUTPUT_PDF")"
+
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║       Export Slides to PDF            ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════╝${NC}"
+echo ""
+
+# ─── Step 1: Check dependencies ───────────────────────────
+
+info "Checking dependencies..."
+
+if ! command -v npx &>/dev/null; then
+    err "Node.js is required but not installed."
+    err ""
+    err "Install Node.js:"
+    err "  macOS:   brew install node"
+    err "  or visit https://nodejs.org and download the installer"
+    exit 1
+fi
+
+ok "Node.js found"
+
+# ─── Step 2: Create the export script ─────────────────────
+
+# We use a temporary Node.js script with Playwright to:
+# 1. Start a local server (so fonts load correctly)
+# 2. Navigate to each slide
+# 3. Screenshot each slide at 1920x1080 (16:9 landscape)
+# 4. Combine into a single PDF
+
+TEMP_DIR=$(mktemp -d)
+TEMP_SCRIPT="$TEMP_DIR/export-slides.mjs"
+
+# Figure out which directory to serve (the folder containing the HTML)
+SERVE_DIR=$(dirname "$INPUT_HTML")
+HTML_FILENAME=$(basename "$INPUT_HTML")
+
+cat > "$TEMP_SCRIPT" << 'EXPORT_SCRIPT'
+// export-slides.mjs — Playwright script to export HTML slides to PDF
+//
+// How it works:
+// 1. Starts a local HTTP server (needed for fonts/assets to load)
+// 2. Opens the presentation in a headless browser at 1920x1080
+// 3. Counts the total number of slides
+// 4. Screenshots each slide one by one
+// 5. Generates a PDF with all slides as landscape pages
+
+import { chromium } from 'playwright';
+import { createServer } from 'http';
+import { readFileSync, existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
+import { join, extname, resolve } from 'path';
+import { execSync } from 'child_process';
+
+const SERVE_DIR = process.argv[2];
+const HTML_FILE = process.argv[3];
+const OUTPUT_PDF = process.argv[4];
+const SCREENSHOT_DIR = process.argv[5];
+const VP_WIDTH = parseInt(process.argv[6]) || 1920;
+const VP_HEIGHT = parseInt(process.argv[7]) || 1080;
+
+// ─── Simple static file server ────────────────────────────
+// (We need HTTP so that Google Fonts and relative assets load correctly)
+
+const MIME_TYPES = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.eot': 'application/vnd.ms-fontobject',
+};
+
+const server = createServer((req, res) => {
+  // Decode URL-encoded characters (e.g., %20 → space) so filenames with spaces resolve correctly
+  const decodedUrl = decodeURIComponent(req.url);
+  let filePath = join(SERVE_DIR, decodedUrl === '/' ? HTML_FILE : decodedUrl);
+  try {
+    const content = readFileSync(filePath);
+    const ext = extname(filePath).toLowerCase();
+    res.writeHead(200, { 'Content-Type': MIME_TYPES[ext] || 'application/octet-stream' });
+    res.end(content);
+  } catch {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+// Find a free port
+const port = await new Promise((resolve) => {
+  server.listen(0, () => resolve(server.address().port));
+});
+
+console.log(`  Local server on port ${port}`);
+
+// ─── Screenshot each slide ────────────────────────────────
+
+const browser = await chromium.launch();
+const page = await browser.newPage({
+  viewport: { width: VP_WIDTH, height: VP_HEIGHT },
+});
+
+// Load the presentation
+await page.goto(`http://localhost:${port}/`, { waitUntil: 'networkidle' });
+
+// Wait for fonts to load
+await page.evaluate(() => document.fonts.ready);
+
+// Extra wait for animations to settle on the first slide
+await page.waitForTimeout(1500);
+
+// Count slides
+const slideCount = await page.evaluate(() => {
+  return document.querySelectorAll('.slide').length;
+});
+
+console.log(`  Found ${slideCount} slides`);
+
+if (slideCount === 0) {
+  // No .slide elements → this is a scrolling document (one-pager, proposal,
+  // brief, microsite, report), not a slide deck. Export the whole page as a
+  // single PDF, honoring the document's own @media print rules and page breaks.
+  console.log('  No .slide elements — exporting as a full-page document PDF');
+  await page.emulateMedia({ media: 'print' });
+  await page.pdf({
+    path: OUTPUT_PDF,
+    printBackground: true,
+    preferCSSPageSize: true,   // respect any @page size the document defines
+    format: 'Letter',          // fallback when the document sets no @page size
+    margin: { top: '0.4in', right: '0.4in', bottom: '0.4in', left: '0.4in' },
+  });
+  await browser.close();
+  server.close();
+  console.log(`  ✓ PDF saved to: ${OUTPUT_PDF}`);
+  process.exit(0);
+}
+
+// Screenshot each slide
+mkdirSync(SCREENSHOT_DIR, { recursive: true });
+const screenshotPaths = [];
+
+for (let i = 0; i < slideCount; i++) {
+  // Navigate to slide by simulating the presentation's navigation
+  // Most frontend-slides presentations use a currentSlide index and show/hide
+  await page.evaluate((index) => {
+    const slides = document.querySelectorAll('.slide');
+
+    // Try multiple navigation strategies used by frontend-slides:
+
+    // Strategy 1: Direct slide manipulation (most common in generated decks)
+    slides.forEach((slide, idx) => {
+      if (idx === index) {
+        slide.style.display = '';
+        slide.style.opacity = '1';
+        slide.style.visibility = 'visible';
+        slide.style.position = 'relative';
+        slide.style.transform = 'none';
+        slide.classList.add('active');
+      } else {
+        slide.style.display = 'none';
+        slide.classList.remove('active');
+      }
+    });
+
+    // Strategy 2: If there's a SlidePresentation class instance, use it
+    if (window.presentation && typeof window.presentation.goToSlide === 'function') {
+      window.presentation.goToSlide(index);
+    }
+
+    // Strategy 3: Scroll-based (some decks use scroll snapping)
+    slides[index]?.scrollIntoView({ behavior: 'instant' });
+  }, i);
+
+  // Wait for any slide transition animations to finish
+  await page.waitForTimeout(300);
+
+  // Wait for intersection observer animations to trigger
+  await page.waitForTimeout(200);
+
+  // Force all .reveal elements on the current slide to be visible
+  // (animations normally trigger on scroll/intersection, but we need them visible now)
+  await page.evaluate((index) => {
+    const slides = document.querySelectorAll('.slide');
+    const currentSlide = slides[index];
+    if (currentSlide) {
+      currentSlide.querySelectorAll('.reveal').forEach(el => {
+        el.style.opacity = '1';
+        el.style.transform = 'none';
+        el.style.visibility = 'visible';
+      });
+    }
+  }, i);
+
+  await page.waitForTimeout(100);
+
+  const screenshotPath = join(SCREENSHOT_DIR, `slide-${String(i + 1).padStart(3, '0')}.png`);
+  await page.screenshot({ path: screenshotPath, fullPage: false });
+  screenshotPaths.push(screenshotPath);
+  console.log(`  Captured slide ${i + 1}/${slideCount}`);
+}
+
+await browser.close();
+server.close();
+
+// ─── Combine screenshots into PDF ─────────────────────────
+// Use a second Playwright page to generate a PDF from the screenshots
+
+console.log('  Assembling PDF...');
+
+const browser2 = await chromium.launch();
+const pdfPage = await browser2.newPage();
+
+// Build an HTML page with all screenshots, one per page
+const imagesHtml = screenshotPaths.map((p) => {
+  const imgData = readFileSync(p).toString('base64');
+  return `<div class="page"><img src="data:image/png;base64,${imgData}" /></div>`;
+}).join('\n');
+
+const pdfHtml = `<!DOCTYPE html>
+<html>
+<head>
+<style>
+  * { margin: 0; padding: 0; }
+  @page { size: ${VP_WIDTH}px ${VP_HEIGHT}px; margin: 0; }
+  .page {
+    width: ${VP_WIDTH}px;
+    height: ${VP_HEIGHT}px;
+    page-break-after: always;
+    overflow: hidden;
+  }
+  .page:last-child { page-break-after: auto; }
+  img {
+    width: ${VP_WIDTH}px;
+    height: ${VP_HEIGHT}px;
+    display: block;
+    object-fit: contain;
+  }
+</style>
+</head>
+<body>${imagesHtml}</body>
+</html>`;
+
+await pdfPage.setContent(pdfHtml, { waitUntil: 'load' });
+await pdfPage.pdf({
+  path: OUTPUT_PDF,
+  width: `${VP_WIDTH}px`,
+  height: `${VP_HEIGHT}px`,
+  printBackground: true,
+  margin: { top: 0, right: 0, bottom: 0, left: 0 },
+});
+
+await browser2.close();
+
+// Clean up screenshots
+screenshotPaths.forEach(p => unlinkSync(p));
+
+console.log(`  ✓ PDF saved to: ${OUTPUT_PDF}`);
+EXPORT_SCRIPT
+
+# ─── Step 3: Install Playwright in temp directory ──────────
+# We install Playwright locally in the temp dir so the Node script can import it.
+# This avoids polluting global packages and ensures the script is self-contained.
+
+info "Setting up Playwright (headless browser for screenshots)..."
+info "This may take a moment on first run..."
+echo ""
+
+cd "$TEMP_DIR"
+
+# Create a minimal package.json so npm install works
+cat > "$TEMP_DIR/package.json" << 'PKG'
+{ "name": "slide-export", "private": true, "type": "module" }
+PKG
+
+# Install Playwright into the temp directory
+npm install playwright &>/dev/null || {
+    err "Failed to install Playwright."
+    err "Try running: npm install playwright"
+    rm -rf "$TEMP_DIR"
+    exit 1
+}
+
+# Ensure Chromium browser binary is downloaded
+npx playwright install chromium 2>/dev/null || {
+    err "Failed to install Chromium browser for Playwright."
+    err "Try running manually: npx playwright install chromium"
+    rm -rf "$TEMP_DIR"
+    exit 1
+}
+ok "Playwright ready"
+echo ""
+
+# ─── Step 4: Run the export ───────────────────────────────
+
+SCREENSHOT_DIR="$TEMP_DIR/screenshots"
+
+info "Exporting slides to PDF..."
+echo ""
+
+# Run from the temp dir so Node can find the locally-installed playwright
+if [[ "$COMPACT" == "true" ]]; then
+    info "Using compact mode (1280×720) for smaller file size"
+fi
+
+node "$TEMP_SCRIPT" "$SERVE_DIR" "$HTML_FILENAME" "$OUTPUT_PDF" "$SCREENSHOT_DIR" "$VIEWPORT_W" "$VIEWPORT_H" || {
+    err "PDF export failed."
+    rm -rf "$TEMP_DIR"
+    exit 1
+}
+
+# ─── Step 5: Cleanup and success ──────────────────────────
+
+rm -rf "$TEMP_DIR"
+
+echo ""
+echo -e "${BOLD}════════════════════════════════════════${NC}"
+ok "PDF exported successfully!"
+echo ""
+echo -e "  ${BOLD}File:${NC}  $OUTPUT_PDF"
+echo ""
+FILE_SIZE=$(du -h "$OUTPUT_PDF" | cut -f1 | xargs)
+echo "  Size: $FILE_SIZE"
+echo ""
+echo "  This PDF works everywhere — email, Slack, Notion, print."
+echo "  Note: Animations are not preserved (it's a static export)."
+echo -e "${BOLD}════════════════════════════════════════${NC}"
+echo ""
+
+# Open the PDF automatically
+if command -v open &>/dev/null; then
+    open "$OUTPUT_PDF"
+elif command -v xdg-open &>/dev/null; then
+    xdg-open "$OUTPUT_PDF"
+fi

--- a/scripts/extract-pptx.py
+++ b/scripts/extract-pptx.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Extract all content from a PowerPoint file (.pptx).
+Returns a JSON structure with slides, text, and images.
+
+Usage:
+    python extract-pptx.py <input.pptx> [output_dir]
+
+Requires: pip install python-pptx
+"""
+
+import json
+import os
+import sys
+from pptx import Presentation
+
+
+def extract_pptx(file_path, output_dir="."):
+    """
+    Extract all content from a PowerPoint file.
+    Returns a list of slide data dicts with text, images, and notes.
+    """
+    prs = Presentation(file_path)
+    slides_data = []
+
+    # Create assets directory for extracted images
+    assets_dir = os.path.join(output_dir, "assets")
+    os.makedirs(assets_dir, exist_ok=True)
+
+    for slide_num, slide in enumerate(prs.slides):
+        slide_data = {
+            "number": slide_num + 1,
+            "title": "",
+            "content": [],
+            "images": [],
+            "notes": "",
+        }
+
+        for shape in slide.shapes:
+            # Extract text content
+            if shape.has_text_frame:
+                if shape == slide.shapes.title:
+                    slide_data["title"] = shape.text
+                else:
+                    slide_data["content"].append(
+                        {"type": "text", "content": shape.text}
+                    )
+
+            # Extract images
+            if shape.shape_type == 13:  # Picture type
+                image = shape.image
+                image_bytes = image.blob
+                image_ext = image.ext
+                image_name = f"slide{slide_num + 1}_img{len(slide_data['images']) + 1}.{image_ext}"
+                image_path = os.path.join(assets_dir, image_name)
+
+                with open(image_path, "wb") as f:
+                    f.write(image_bytes)
+
+                slide_data["images"].append(
+                    {
+                        "path": f"assets/{image_name}",
+                        "width": shape.width,
+                        "height": shape.height,
+                    }
+                )
+
+        # Extract speaker notes
+        if slide.has_notes_slide:
+            notes_frame = slide.notes_slide.notes_text_frame
+            slide_data["notes"] = notes_frame.text
+
+        slides_data.append(slide_data)
+
+    return slides_data
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python extract-pptx.py <input.pptx> [output_dir]")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else "."
+
+    slides = extract_pptx(input_file, output_dir)
+
+    # Write extracted data as JSON
+    output_path = os.path.join(output_dir, "extracted-slides.json")
+    with open(output_path, "w") as f:
+        json.dump(slides, f, indent=2)
+
+    print(f"Extracted {len(slides)} slides to {output_path}")
+    for s in slides:
+        img_count = len(s["images"])
+        print(f"  Slide {s['number']}: {s['title'] or '(no title)'} — {img_count} image(s)")

--- a/skills/battlecard-doc/SKILL.md
+++ b/skills/battlecard-doc/SKILL.md
@@ -231,6 +231,10 @@ Want me to:
 
 ```
 To save as PDF:
+
+PDF (recommended): bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh .octave-decks/battlecard-<competitor>-<date>/battlecard-<competitor>.html
+  — or use the manual print dialog below:
+
 1. Open the file in your browser (should already be open)
 2. Press Cmd+P (Mac) or Ctrl+P (Windows)
 3. Select "Save as PDF" as the destination

--- a/skills/brief/SKILL.md
+++ b/skills/brief/SKILL.md
@@ -330,7 +330,7 @@ Navigation:
 - Scroll naturally to read through sections
 - Click nav dots on the right edge to jump to sections
 - Click section headers to collapse/expand
-- Print-friendly: Cmd+P / Ctrl+P for clean PDF output
+- PDF (recommended): bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh .octave-briefs/<brief-name>-<date>/<brief-name>.html  — or Cmd+P / Ctrl+P -> Save as PDF
 
 ---
 

--- a/skills/deck/SKILL.md
+++ b/skills/deck/SKILL.md
@@ -7,7 +7,7 @@ description: Octave-powered presentation builder that researches, structures, an
 
 Build compelling, self-contained HTML presentations powered by your Octave GTM knowledge base. Unlike generic slide builders, this skill leverages your library's personas, competitors, Motion ICP narratives, proof points, and real conversation data to research, structure, and generate presentations grounded in your actual go-to-market intelligence.
 
-> HTML presentation engine inspired by [frontend-slides](https://github.com/zarazhangrui/frontend-slides) by Zara Zhang (MIT license).
+> HTML presentation engine inspired by [frontend-slides](https://github.com/zarazhangrui/frontend-slides) by Zara Zhang (MIT license). Decks render on a **fixed 1920×1080 stage scaled to the viewport** (see [references/viewport-base.css](references/viewport-base.css)).
 
 ## Usage
 
@@ -135,6 +135,21 @@ Your choice:
 | Sales enablement | Long (18-25) |
 
 Use the recommended default as the pre-selected option. If the user picks "Custom," ask for a target slide count.
+
+**Density — "How should each slide read?"**
+
+```
+How dense should each slide be?
+
+1. Speaker-led (low density) — big ideas, generous space, 1-3 bullets max,
+   more slides. Best for live pitches, keynotes, exec rooms.
+2. Reading-first (high density) — self-contained, structured grids,
+   4-8 bullets or 4-6 cards, tighter spacing. Best for QBRs, async/leave-behind decks.
+
+Your choice:
+```
+
+Default by purpose: pitches/keynotes/competitive → **speaker-led**; QBRs/enablement/launch/strategy → **reading-first**. Carry this choice through Step 5: it drives the content density limits per slide type (split into more slides rather than shrink text or overflow). Either way, no scrolling and no cramped text — the fixed stage scales the whole slide, it does not add room.
 
 ### Step 2: Octave-Powered Context Gathering
 
@@ -325,61 +340,72 @@ Does this outline look good? I can:
 Ask the user:
 
 ```
-Do you want to use your company's brand styling?
+Whose brand should this deck reflect — and how should we style it?
 
-1. Yes — extract from my website (provide URL)
-2. Yes — I'll provide brand assets (colors, fonts, logo)
-3. No — I'll pick from style presets
-4. Use Octave brand styling
+1. My brand (the sender) — extract from my website (give the URL)
+2. The audience's brand — mirror the recipient's company so the deck feels built for them (give *their* URL). Common for customer pitches and ABM.
+3. I'll provide brand assets directly (colors, fonts, logo)
+4. No brand — pick from style presets
+5. Use Octave brand styling
 
 Your choice:
 ```
 
-If user wants brand extraction:
+> **Whose brand decides which website you fetch.** This is the key fork: for option 1 run the extraction against *your own* domain; for option 2 run it against the *audience's/recipient's* domain. Everything below targets that chosen domain.
 
-**Tier 1: browser-use (best quality, if available)**
+If user wants brand extraction, work down these tiers — start at Tier 1 and only fall through when a tier is unavailable. Tiers 1–2 are the fast, high-quality path; combine both when you can (colors+logo from Tier 1, fonts+components from Tier 2).
+
+**Tier 1: Octave brand-assets tool (first-party, fast — try first)**
+```
+get_external_brand_assets({ url: "https://<domain>" })
+  → colors (primary / secondary / accent), logo variants, backdrop images, brand name
+get_external_brand_logo({ domain: "<domain>" })   # if you only need the single best logo
+```
+This is one call for the visual identity and the right default. **Sanity-check the result — the scraper reads the DOM and can misattribute a homepage logo wall:**
+- If `brandName` doesn't match the target company, ignore it (it likely grabbed a customer name).
+- A strip of many logos with varied aspect ratios is usually a **"trusted by" customer wall**, not the brand's own logo — don't use those as the deck logo. Prefer the `favicon` / `apple-touch-icon` entries or the nav wordmark.
+- The `colors` are usually reliable; still confirm with the user.
+
+**Tier 2: `scrape_website` — components & typography (the "looks like their site" leap)**
+```
+scrape_website({ url: "https://<domain>",        format: "html", includeScreenshot: true })
+scrape_website({ url: "https://<representative-page>", format: "html", includeScreenshot: true })
+```
+Pull the homepage **and one representative page** (case study, blog post, pricing, or product page). Then:
+- **From the screenshot(s):** read the component vocabulary the DOM hides — button shapes, card styles, corner radii, spacing rhythm, type scale, section patterns, use of gradients/imagery. Emulate this *component and layout system*, not just the colors.
+- **From the html:** extract exact fonts (`font-family`, Google Fonts `<link>`s / `@font-face`), CSS custom properties (`--brand-*`, `--color-*`), and the real copy tone.
+
+> If `scrape_website` isn't available in this workspace yet, skip to Tier 3.
+
+**Tier 3: browser-use (fallback if `scrape_website` unavailable)**
 ```
 1. browser-use open <website-url>
 2. browser-use screenshot brand-capture.png
 3. browser-use eval "(() => {
-     const styles = getComputedStyle(document.documentElement);
      const body = getComputedStyle(document.body);
      return {
-       bgColor: body.backgroundColor,
-       textColor: body.color,
-       fontFamily: body.fontFamily,
+       bgColor: body.backgroundColor, textColor: body.color, fontFamily: body.fontFamily,
        links: getComputedStyle(document.querySelector('a') || document.body).color,
        headings: getComputedStyle(document.querySelector('h1,h2,h3') || document.body).fontFamily,
-       logos: [...document.querySelectorAll('img[src*=logo], svg[class*=logo], header img')].map(e => e.src || 'inline-svg').slice(0, 3)
+       logos: [...document.querySelectorAll('header img, img[src*=logo], svg[class*=logo]')].map(e => e.src || 'inline-svg').slice(0, 3)
      };
    })()"
 4. browser-use extract "List the primary brand colors (hex), fonts, and logo URLs visible on this page"
-5. Combine extractions into brand config
-6. Show to user for confirmation
 ```
 
-**Tier 2: WebFetch (if browser-use unavailable)**
+**Tier 4: WebFetch (fallback if browser-use unavailable)**
 ```
 1. WebFetch the homepage URL
-2. Parse HTML/CSS for:
-   - CSS custom properties (--brand-*, --color-*, --primary, etc.)
-   - font-family declarations from body, h1-h3
-   - Logo URLs from <img>, <svg>, og:image meta tags
-   - meta theme-color
-3. Show extracted brand config to user for confirmation
+2. Parse HTML/CSS for CSS custom properties (--brand-*, --color-*), font-family on body/h1-h3,
+   logo URLs from <img>/<svg>/og:image, and meta theme-color
 ```
 
-**Tier 3: Manual (if neither works)**
+**Tier 5: Manual (if nothing automated works)**
 ```
 I couldn't automatically extract your brand. You can:
-
 1. Share your brand guidelines (PDF or link)
 2. Provide hex colors: primary, secondary, background, text
-3. Name your fonts (heading + body)
-4. Share logo files
-5. Try coolors.co/image-picker with a screenshot of your site
-
-Provide what you have:
+3. Name your fonts (heading + body)   4. Share logo files
 ```
 
 **Always confirm the brand config with the user before proceeding:**
@@ -389,17 +415,15 @@ BRAND CONFIG EXTRACTED
 ======================
 
 Colors:
-  Primary:    #XXXXXX ██
-  Secondary:  #XXXXXX ██
-  Background: #XXXXXX ██
-  Text:       #XXXXXX ██
-  Accent:     #XXXXXX ██
+  Primary:    #XXXXXX ██   Secondary: #XXXXXX ██   Accent: #XXXXXX ██
+  Background: #XXXXXX ██   Text:      #XXXXXX ██
 
-Fonts:
-  Headings: [Font name]
-  Body: [Font name]
+Fonts:    Headings: [Font name]    Body: [Font name]
 
-Logo: [URL or file path]
+Logo:     [URL or file path]   (verified as the brand's own, not a customer logo)
+
+Components observed (from screenshots, if Tier 2 ran):
+  • [e.g. pill buttons, 12px card radius, generous section spacing, gradient accents]
 
 Does this look right? (y/n/adjust)
 ```
@@ -435,18 +459,20 @@ What impression should the deck make?
 Your mood:
 ```
 
-Generate **3 single-slide HTML preview files** based on the mood. Use the first slide from the outline as content. Save to `.octave-decks/slide-previews/`:
+Generate **3 single-slide HTML preview files** — show, don't tell. Each is a real, animated **title slide using the user's actual first-slide content** (title, subtitle, date, author, logo if available). Never render "Option A", "preview", a preset/template name, or any file path *on the slide itself*. Save to `.octave-decks/slide-previews/` as `style-a.html`, `style-b.html`, `style-c.html`, built on the **fixed 1920×1080 stage** (paste `viewport-base.css`).
 
-| Mood | Preview Presets |
+**Preview mix:** generate previews from the mood-matched presets in [references/style-presets.md](references/style-presets.md), optionally swapping one for a custom wildcard:
+
+| Mood | Preview presets |
 |------|----------------|
 | Impressed | `midnight-pro`, `executive-dark`, `octave-brand` |
 | Excited | `electric-studio`, `neon-pulse`, `solar-flare` |
 | Calm | `swiss-modern`, `soft-light`, `paper-minimal` |
 | Inspired | `dark-botanical`, `aurora-gradient`, `monochrome-bold` |
 
-If brand was extracted in Step 3, add a **4th brand-themed preview**.
+For more range, make one of the three a **custom wildcard** — a self-generated design that follows the no-slop rules (distinctive typography, avoid Inter/Roboto/system fonts; a committed palette, no generic purple-on-white; a recognizable layout system on the fixed 16:9 stage). If brand was extracted in Step 3, add a **4th brand-themed preview**.
 
-Open all previews in the browser for the user to compare, then ask which they prefer.
+Open all previews in the browser for the user to compare, then ask which they prefer (or which elements to mix).
 
 ---
 
@@ -544,15 +570,18 @@ The entire `.octave-decks/` directory is in `.gitignore` — nothing here gets c
 
 #### HTML Architecture
 
-See [html-scaffold.md](references/html-scaffold.md) for the full HTML scaffold of the slide deck.
+See [html-scaffold.md](references/html-scaffold.md) for the full scaffold. **Two non-negotiables:**
 
-#### Viewport Fitting Requirements (Critical)
+1. **Paste the entire [viewport-base.css](references/viewport-base.css)** into the `<style>` block. It provides the `.deck-viewport` → `.deck-stage` (1920×1080) → `.slide` system, `.active`/`.visible` visibility, print-one-slide-per-page, and reduced-motion.
+2. **Author every slide at 1920×1080 in px** — no `clamp()`, `vw`, or `vh` for layout. The stage scales as a whole to fit any screen.
 
-These rules are non-negotiable. Every slide must fit within 100vh/100dvh without scrolling:
+#### Fixed-Canvas Fitting (Critical)
 
-1. **All font sizes use `clamp()`** — responsive to viewport, never fixed px
-2. **All spacing uses `clamp()`** — padding, margins, gaps scale with viewport
-3. **Content density limits per slide type:**
+Every slide is a fixed 1920×1080 canvas; the controller scales the whole stage. Fit is achieved by **density discipline**, not responsive math:
+
+1. **Size in px against the 1920×1080 canvas.** A title is ~96–120px, body ~24–32px, slide padding ~80×140px. Translate any `clamp()`/`vw` from a preset or custom design into fixed px.
+2. **`overflow: hidden` on every `.slide`** (from viewport-base.css) — anything that doesn't fit is clipped, so it must fit by design.
+3. **Content density limits per slide type** (tighten for *speaker-led*, allow the upper bound for *reading-first* — see Step 1 density choice):
 
 | Slide Type | Max Content |
 |-----------|------------|
@@ -569,29 +598,20 @@ These rules are non-negotiable. Every slide must fit within 100vh/100dvh without
 | Agenda/TOC | 1 heading + 5-8 agenda items |
 | CTA/Closing | 1 heading + 1-2 lines + 1 action |
 
-4. **If content exceeds limits** — split into multiple slides. Never overflow.
-5. **Media queries for short viewports:**
-   ```css
-   @media (max-height: 700px) { /* Reduce font sizes ~10% */ }
-   @media (max-height: 600px) { /* Reduce further, tighten padding */ }
-   @media (max-height: 500px) { /* Minimal mode */ }
-   ```
-6. **`overflow: hidden`** on every `.slide` — content that doesn't fit is invisible, so it must fit
+4. **If content exceeds limits — split into more slides.** Never shrink text below readable size and never overflow.
+5. **Verify before delivery.** If browser-use is available, open the deck and screenshot a few slides to check for clipped text or overlapping panels (a card can pass a height check while still being covered by another grid panel). Fix by splitting or reducing content.
 
 #### Animation Patterns
 
-Staggered entrance animations triggered by Intersection Observer:
+Reveals are triggered by the `.visible` class the controller toggles on the active slide (no Intersection Observer — slides switch via `.active`/`.visible`, not scroll):
 
 ```css
-.slide .animate-in {
+.animate-in {
   opacity: 0;
-  transform: translateY(20px);
+  transform: translateY(30px);
   transition: opacity 0.6s var(--ease), transform 0.6s var(--ease);
 }
-.slide.visible .animate-in {
-  opacity: 1;
-  transform: translateY(0);
-}
+.slide.visible .animate-in { opacity: 1; transform: translateY(0); }
 /* Stagger children */
 .slide.visible .animate-in:nth-child(1) { transition-delay: 0.1s; }
 .slide.visible .animate-in:nth-child(2) { transition-delay: 0.2s; }
@@ -599,28 +619,32 @@ Staggered entrance animations triggered by Intersection Observer:
 /* ... up to 8 */
 ```
 
-Additional animation options (use sparingly):
-- **Counter animation** for metrics: numbers count up when slide visible
-- **Draw-in** for borders/lines: width/height transitions from 0
-- **Fade-scale** for cards: `transform: scale(0.95)` to `scale(1)`
-
-Always respect `prefers-reduced-motion`:
-```css
-@media (prefers-reduced-motion: reduce) {
-  .slide .animate-in { opacity: 1; transform: none; transition: none; }
-}
-```
+Match motion to the chosen style (see [references/animation-patterns.md](references/animation-patterns.md) for the effect-to-feeling guide and snippets: fade/slide, scale-in, blur-in, gradient-mesh backgrounds, 3D tilt). Use extras sparingly: counter animations for metrics, draw-in for borders, fade-scale for cards. `prefers-reduced-motion` is already handled by viewport-base.css.
 
 #### Navigation Implementation
 
+A small `SlidePresentation` controller (in the scaffold) handles everything — **no scroll-snap, no nav dots**:
+
 ```javascript
-// Generate nav dots from slide count
-// Scroll snap handles primary navigation
-// Keyboard: ArrowDown/Right/Space = next, ArrowUp/Left = prev
-// Progress bar: width = (currentSlide / totalSlides) * 100%
-// Intersection Observer triggers .visible class for animations
-// Touch support via scroll snap (native)
+// 1. Stage scaling: transform = translate(x,y) scale(min(vw/1920, vh/1080)); re-fit on resize
+// 2. show(i): toggle .active + .visible on the target slide (re-runs .animate-in reveals)
+// 3. Keyboard: ArrowRight/PageDown/Space = next; ArrowLeft/PageUp = prev; Home/End; R = reset
+// 4. Touch: swipe left/right
+// 5. #deckControls (outside the stage, so it isn't scaled): "n / total" + prev/next buttons
 ```
+
+#### Avoid AI Slop
+
+Whether using a preset or a custom wildcard, the output should look intentional, not generated:
+
+- **Fonts:** avoid Inter, Roboto, Arial, and raw system fonts for *custom* looks. Reach for distinctive display faces (Fontshare/Google Fonts). (Brand presets that specify a brand font are fine.)
+- **Color:** commit to a palette with a sharp accent — avoid generic purple-gradient-on-white and timid washes.
+- **Layout:** vary slide types; avoid cookie-cutter "title + 3 bullets" on every slide.
+- **Context:** the design should fit the occasion and audience (a board deck and a hackathon demo should not look alike).
+
+#### Inline Editing (included by default)
+
+Add a lightweight in-browser editor so the user can tweak copy without touching code. Do **not** ask about it during intake — include it unless the user requested a locked/export-only deck. Implementation details (the JS-based hover with a 400ms grace period — **not** a CSS `~` sibling selector, which breaks because `pointer-events:none` drops the hover chain — plus the `E` shortcut and stripping edit state on export) are in [html-scaffold.md](references/html-scaffold.md).
 
 #### Slide Type Templates
 
@@ -645,15 +669,20 @@ Style:  [Preset name or "Custom Brand"]
 Size:   [file size]
 
 Navigation:
-• Scroll or swipe to navigate between slides
-• Keyboard: Arrow keys, Space, Page Up/Down
-• Click nav dots on the right edge
+• Arrow keys / Space / Page Up-Down to move; Home/End to jump; R to reset
+• Swipe left/right on touch devices
+• Prev/next + "n / total" controls at the bottom
+• Scales to fit any screen (fixed 16:9 stage, letterboxed)
+
+Editing:
+• Hover the top-left corner (or press E) to toggle inline edit mode, then
+  click any text to edit. Export saves a clean copy with edit state stripped.
 
 Customization tips:
-• Colors: Edit the :root CSS variables at the top of the file
-• Content: Each <section class="slide"> is one slide
-• Fonts: Change the Google Fonts <link> and font-family values
-• Add slides: Copy a <section> block, increment data-slide
+• Colors/fonts: edit the :root CSS variables at the top of the file
+• Content: each <section class="slide"> inside .deck-stage is one slide
+• Add slides: copy a <section class="slide"> block (only the first carries
+  "active visible")
 
 ---
 
@@ -662,13 +691,19 @@ Want me to:
 2. Change the style/colors
 3. Add or remove slides
 4. Create a version for a different audience
-5. Export to another format (PPTX, PDF, LinkedIn Carousel, Google Slides, Gamma)
+5. Export or share (PDF, live URL/Vercel, LinkedIn Carousel, PPTX, Google Slides, Gamma)
 6. Done
 ```
 
-### Step 7: Export (Optional)
+### Step 7: Export & Share (Optional)
 
-Consult [references/export-guide.md](references/export-guide.md) for detailed export instructions for each format: PDF, LinkedIn Carousel, PPTX, Google Slides, Gamma, and Markdown.
+Consult [references/export-guide.md](references/export-guide.md) for detailed instructions per format:
+
+- **PDF** — `bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh <deck>.html` (headless Playwright, one slide/page; `--compact` for smaller files). Browser print is the fallback.
+- **Live URL** — `bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/deploy.sh <deck-folder>/` deploys to Vercel and returns a public link that works on any device.
+- **LinkedIn Carousel, PPTX, Google Slides, Gamma, Markdown** — as documented in the export guide.
+
+> `export-pdf.sh` and `deploy.sh` are generic — the same commands work for any HTML output from the other Octave skills (one-pager, proposal, microsite, brief, win-loss-report).
 
 ---
 
@@ -760,6 +795,9 @@ for i, slide in enumerate(prs.slides):
 - `generate_email` - Generate email content (for follow-up slides)
 
 ### Brand & Style
+- `get_external_brand_assets` - Scrape a URL for brand colors, logo variants, backdrop images, brand name (Tier 1 brand extraction)
+- `get_external_brand_logo` - Single best logo URL for a domain
+- `scrape_website` - Fetch a page as markdown/html with an optional screenshot (`{ format, includeScreenshot }`) — used to read components/typography for brand emulation (Tier 2)
 - `list_all_entities` (entityType: "brand_voice") - Available brand voices in workspace
 - `list_writing_styles` - Available writing styles in workspace
 

--- a/skills/deck/references/animation-patterns.md
+++ b/skills/deck/references/animation-patterns.md
@@ -1,0 +1,110 @@
+# Animation Patterns Reference
+
+Use this reference when generating presentations. Match animations to the intended feeling.
+
+## Effect-to-Feeling Guide
+
+| Feeling | Animations | Visual Cues |
+|---------|-----------|-------------|
+| **Dramatic / Cinematic** | Slow fade-ins (1-1.5s), large scale transitions (0.9 to 1), parallax scrolling | Dark backgrounds, spotlight effects, full-bleed images |
+| **Techy / Futuristic** | Neon glow (box-shadow), glitch/scramble text, grid reveals | Particle systems (canvas), grid patterns, monospace accents, cyan/magenta/electric blue |
+| **Playful / Friendly** | Bouncy easing (spring physics), floating/bobbing | Rounded corners, pastel/bright colors, hand-drawn elements |
+| **Professional / Corporate** | Subtle fast animations (200-300ms), clean slides | Navy/slate/charcoal, precise spacing, data visualization focus |
+| **Calm / Minimal** | Very slow subtle motion, gentle fades | High whitespace, muted palette, serif typography, generous padding |
+| **Editorial / Magazine** | Staggered text reveals, image-text interplay | Strong type hierarchy, pull quotes, grid-breaking layouts, serif headlines + sans body |
+
+## Entrance Animations
+
+```css
+/* Fade + Slide Up (most versatile) */
+.reveal {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: opacity 0.6s var(--ease-out-expo),
+                transform 0.6s var(--ease-out-expo);
+}
+.visible .reveal {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Scale In */
+.reveal-scale {
+    opacity: 0;
+    transform: scale(0.9);
+    transition: opacity 0.6s, transform 0.6s var(--ease-out-expo);
+}
+
+/* Slide from Left */
+.reveal-left {
+    opacity: 0;
+    transform: translateX(-50px);
+    transition: opacity 0.6s, transform 0.6s var(--ease-out-expo);
+}
+
+/* Blur In */
+.reveal-blur {
+    opacity: 0;
+    filter: blur(10px);
+    transition: opacity 0.8s, filter 0.8s var(--ease-out-expo);
+}
+```
+
+## Background Effects
+
+```css
+/* Gradient Mesh — layered radial gradients for depth */
+.gradient-bg {
+    background:
+        radial-gradient(ellipse at 20% 80%, rgba(120, 0, 255, 0.3) 0%, transparent 50%),
+        radial-gradient(ellipse at 80% 20%, rgba(0, 255, 200, 0.2) 0%, transparent 50%),
+        var(--bg-primary);
+}
+
+/* Noise Texture — inline SVG for grain */
+.noise-bg {
+    background-image: url("data:image/svg+xml,..."); /* Inline SVG noise */
+}
+
+/* Grid Pattern — subtle structural lines */
+.grid-bg {
+    background-image:
+        linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px);
+    background-size: 50px 50px;
+}
+```
+
+## Interactive Effects
+
+```javascript
+/* 3D Tilt on Hover — adds depth to cards/panels */
+class TiltEffect {
+    constructor(element) {
+        this.element = element;
+        this.element.style.transformStyle = 'preserve-3d';
+        this.element.style.perspective = '1000px';
+
+        this.element.addEventListener('mousemove', (e) => {
+            const rect = this.element.getBoundingClientRect();
+            const x = (e.clientX - rect.left) / rect.width - 0.5;
+            const y = (e.clientY - rect.top) / rect.height - 0.5;
+            this.element.style.transform = `rotateY(${x * 10}deg) rotateX(${-y * 10}deg)`;
+        });
+
+        this.element.addEventListener('mouseleave', () => {
+            this.element.style.transform = 'rotateY(0) rotateX(0)';
+        });
+    }
+}
+```
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| Fonts not loading | Check Fontshare/Google Fonts URL; ensure font names match in CSS |
+| Animations not triggering | Verify Intersection Observer is running; check `.visible` class is being added |
+| Scroll snap not working | Ensure `scroll-snap-type: y mandatory` on html; each slide needs `scroll-snap-align: start` |
+| Mobile issues | Disable heavy effects at 768px breakpoint; test touch events; reduce particle count |
+| Performance issues | Use `will-change` sparingly; prefer `transform`/`opacity` animations; throttle scroll handlers |

--- a/skills/deck/references/export-guide.md
+++ b/skills/deck/references/export-guide.md
@@ -1,21 +1,22 @@
 # Deck Export Guide
 
-## Export Options
+## Export & Share Options
 
-When the user selects "Export to another format," present options:
+When the user selects "Export or share," present options:
 
 ```
-EXPORT OPTIONS
-==============
+EXPORT & SHARE OPTIONS
+======================
 
                         Styling  Editable  Notes
-1. PDF              *****  No        Print of HTML — full visual fidelity
-2. LinkedIn Carousel*****  No        Portrait PDF (1080x1350) — full fidelity
-3. PPTX             **     Yes       Text + basic colors only (no gradients/animations/clamp)
-4. Google Slides    **     Yes       Via PPTX import — same limitations
-5. Gamma            *      Yes       Text outline only — Gamma applies its own styling
-6. Markdown         *      Yes       Plain text structure only
-7. Keep as HTML     *****  Yes       Already saved, full fidelity + editable
+1. PDF              *****  No        Headless render — full visual fidelity, one slide/page
+2. Live URL (Vercel)*****  No        Deploy to a public link — works on any device
+3. LinkedIn Carousel*****  No        Portrait PDF (1080x1350) — full fidelity
+4. PPTX             **     Yes       Text + basic colors only (no gradients/animations)
+5. Google Slides    **     Yes       Via PPTX import — same limitations
+6. Gamma            *      Yes       Text outline only — Gamma applies its own styling
+7. Markdown         *      Yes       Plain text structure only
+8. Keep as HTML     *****  Yes       Already saved, full fidelity + editable
 
 Your choice:
 ```
@@ -24,23 +25,49 @@ Your choice:
 
 ## PDF Export
 
-Use browser-use if available, otherwise instruct the user:
+**Preferred: the `export-pdf.sh` script** (headless Playwright capture — no manual print dialog, one clean slide per page). The script auto-installs Playwright/Chromium into a temp dir on first run (~150MB, ~30–60s), then cleans up.
 
-**With browser-use:**
 ```
-1. browser-use open [presentation-file-path]
-2. browser-use eval "window.print()"
-   # User selects "Save as PDF" in the print dialog
-```
+bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh <path-to-deck>.html
+# → writes <path-to-deck>.pdf next to the HTML and opens it
 
-**Without browser-use:**
+# Smaller file (1280×720 capture, ~50–70% smaller):
+bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh <path-to-deck>.html --compact
 ```
-To save as PDF:
+(`${CLAUDE_PLUGIN_ROOT}` resolves to the installed plugin dir; the `:-.` fallback runs it from the repo root in dev.)
+
+Requirements & gotchas:
+- Node.js must be installed (`brew install node` or nodejs.org).
+- Slides must use `class="slide"` (our scaffold does).
+- Images must use **relative paths** (`src="assets/x.png"`), not absolute filesystem paths.
+- Animations are flattened to their final visual state (it's a static export).
+
+**Fallback (no Node, or script unavailable):** the deck's `@media print` (from `viewport-base.css`) already lays out one slide per page, so the browser print dialog works directly:
+```
 1. Open [file path] in your browser
 2. Press Cmd+P (Mac) or Ctrl+P (Windows)
-3. Select "Save as PDF" as the destination
-4. Set margins to "None" for best results
+3. Destination: "Save as PDF"; Margins: "None"; Background graphics: ON
 ```
+(Or, with browser-use available: `browser-use open [file]` then `browser-use eval "window.print()"`.)
+
+---
+
+## Live URL (Vercel Deploy)
+
+For sharing a deck as a link that works on any device, use the `deploy.sh` script. It checks/installs the Vercel CLI, guides login if needed, resolves local assets, and prints a permanent public URL.
+
+```
+bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/deploy.sh <path-to-deck-folder>/   # deploys the whole folder (assets travel with it)
+# or
+bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/deploy.sh <path-to-deck>.html      # single file → temp index.html
+```
+
+Gotchas:
+- Requires a Vercel account (free); the script walks the user through `vercel login` / signup.
+- Deploy the **folder** (not just the HTML) when the deck references local images, so assets resolve.
+- Redeploying the same project updates the same URL. Take it down from vercel.com/dashboard.
+
+> These two scripts are generic — they work for any self-contained HTML output, so the same `export-pdf.sh` / `deploy.sh` commands apply to one-pagers, proposals, microsites, briefs, and reports too.
 
 ---
 

--- a/skills/deck/references/html-scaffold.md
+++ b/skills/deck/references/html-scaffold.md
@@ -1,5 +1,11 @@
 # Deck HTML Scaffold
 
+The deck uses a **fixed 16:9 stage**: every slide is authored at **1920×1080** and the whole stage is scaled as a unit with `transform: scale()` to fit the browser window (letterboxed/pillarboxed). Content never reflows per device — this guarantees "fits perfectly on every screen" instead of relying on `clamp()` math.
+
+> Authoring rule: size everything in **px against the 1920×1080 canvas** (e.g. a 112px title, 72px padding). Do **not** use `clamp()`, `vw`, or `vh` for layout — the stage scaling handles responsiveness. Treat any `clamp()`/`vw` values from a style preset or custom design as design *proportions* to translate into fixed 1920×1080 coordinates.
+
+The full contents of [`viewport-base.css`](viewport-base.css) are **mandatory** — paste them verbatim into the `<style>` block of every deck. They define the `.deck-viewport` → `.deck-stage` → `.slide` system, `.active`/`.visible` visibility (never `display:none`, so slide state and animations are preserved), print-one-slide-per-page, and reduced-motion.
+
 ```html
 <!DOCTYPE html>
 <html lang="en">
@@ -13,66 +19,135 @@
   <link href="https://fonts.googleapis.com/css2?family=[fonts]&display=swap" rel="stylesheet">
   <style>
     /* === CSS Variables (from chosen preset) === */
-    :root { ... }
-
-    /* === Reset & Base === */
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    html { scroll-snap-type: y mandatory; scroll-behavior: smooth; }
-
-    /* === Slide Container === */
-    .slide {
-      height: 100vh;
-      height: 100dvh;
-      width: 100%;
-      scroll-snap-align: start;
-      overflow: hidden;
-      position: relative;
-      display: flex;
-      align-items: center;
-      justify-content: center;
+    :root {
+      ...                              /* colors/fonts/radius from style-presets.md */
+      --stage-bg: #000;                /* letterbox color behind the stage */
+      --slide-bg: var(--bg);           /* slide canvas background */
     }
 
-    /* === Typography (all clamp-based) === */
-    .heading-1 { font-size: clamp(2rem, 5vw, 4rem); }
-    .heading-2 { font-size: clamp(1.5rem, 3.5vw, 2.75rem); }
-    .heading-3 { font-size: clamp(1rem, 2vw, 1.5rem); }
-    .body-text { font-size: clamp(0.85rem, 1.4vw, 1.05rem); }
+    /* === Reset === */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-    /* === Layout Utilities === */
-    .slide-inner { max-width: 1100px; width: 100%; padding: clamp(1.5rem, 4vh, 3rem) clamp(2rem, 5vw, 6rem); }
-    .grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: clamp(1rem, 2vw, 2rem); }
-    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: clamp(1rem, 2vw, 2rem); }
+    /* === viewport-base.css (PASTE THE ENTIRE FILE HERE — mandatory) === */
+    /* .deck-viewport, .deck-stage (1920×1080), .slide (.active/.visible),
+       @media print one-slide-per-page, prefers-reduced-motion … */
 
-    /* === Components (cards, pills, metrics, etc.) === */
-    /* === Animations === */
-    /* === Navigation (progress bar + nav dots) === */
-    /* === Responsive (max-height media queries) === */
-    /* === prefers-reduced-motion === */
+    /* === Typography — authored at the 1920×1080 stage size (px, not clamp) === */
+    .heading-1   { font-size: 96px;  line-height: 1.05; font-family: var(--font-display); }
+    .heading-2   { font-size: 60px;  line-height: 1.1;  font-family: var(--font-display); }
+    .heading-3   { font-size: 34px;  line-height: 1.2;  font-family: var(--font-display); }
+    .body-lg     { font-size: 32px;  line-height: 1.4; }
+    .body-text   { font-size: 24px;  line-height: 1.5; }
+    .big-number  { font-size: 120px; line-height: 1;   font-family: var(--font-display); }
+
+    /* === Layout — each slide centers a content well inside the 1920×1080 canvas === */
+    .slide { display: flex; align-items: center; justify-content: center; }
+    .slide-inner { width: 100%; max-width: 1600px; padding: 80px 140px; }
+    .flex-center { align-items: center; justify-content: center; }
+    .flex-col { display: flex; flex-direction: column; }
+    .grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 40px; }
+    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 40px; }
+
+    /* === Components (cards, pills, metrics, etc.) — px-sized === */
+
+    /* === Reveal animations: triggered by .visible on the active slide === */
+    .animate-in {
+      opacity: 0;
+      transform: translateY(30px);
+      transition: opacity 0.6s var(--ease), transform 0.6s var(--ease);
+    }
+    .slide.visible .animate-in { opacity: 1; transform: translateY(0); }
+    .slide.visible .animate-in:nth-child(1) { transition-delay: 0.1s; }
+    .slide.visible .animate-in:nth-child(2) { transition-delay: 0.2s; }
+    .slide.visible .animate-in:nth-child(3) { transition-delay: 0.3s; }
+    /* … up to 8 */
   </style>
 </head>
 <body>
 
-  <div id="progress-bar"></div>
-  <nav id="nav-dots"></nav>
+  <div class="deck-viewport">
+    <main class="deck-stage" id="deckStage">
 
-  <!-- Slides -->
-  <section class="slide" data-slide="0">
-    <div class="bg-mesh">...</div>
-    <div class="slide-inner">
-      <!-- Slide content -->
-    </div>
-  </section>
+      <!-- First slide carries `active visible` so it shows + animates on load -->
+      <section class="slide slide-title active visible" data-slide="0">
+        <div class="slide-inner flex-center flex-col">
+          <!-- Slide content (see slide-templates.md) -->
+        </div>
+      </section>
 
-  <!-- Repeat for each slide -->
+      <!-- Subsequent slides: just `slide` -->
+      <section class="slide" data-slide="1">
+        <div class="slide-inner"> ... </div>
+      </section>
+
+      <!-- Repeat for each slide -->
+
+    </main>
+  </div>
+
+  <!-- Presentation chrome lives OUTSIDE the stage so it isn't scaled -->
+  <div class="deck-controls" id="deckControls"></div>
+
+  <!-- Inline editing affordance (included by default — see SKILL.md Step 6) -->
+  <div class="edit-hotzone"></div>
+  <button class="edit-toggle" id="editToggle" title="Edit mode (E)">✏️</button>
 
   <script>
-    // Navigation: keyboard (ArrowDown/Up, Space, PageDown/Up), scroll snap, touch
-    // Progress bar animation
-    // Nav dots generation and active state
-    // Intersection Observer for .animate-in elements
-    // prefers-reduced-motion check
+    /* === Slide controller: fixed-stage scaling + nav + .active/.visible === */
+    class SlidePresentation {
+      constructor() {
+        this.slides = [...document.querySelectorAll('.slide')];
+        this.stage = document.getElementById('deckStage');
+        this.current = 0;
+        this.setupStageScale();   // scale 1920×1080 stage to viewport, recenter on resize
+        this.setupKeyboardNav();  // ArrowR/L, Space, PageUp/Down, Home/End
+        this.setupTouchNav();     // swipe left/right on touch devices
+        this.renderControls();    // "n / total" + prev/next, in #deckControls
+        this.show(0);
+      }
+      setupStageScale() {
+        const fit = () => {
+          const s = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
+          const x = (window.innerWidth  - 1920 * s) / 2;
+          const y = (window.innerHeight - 1080 * s) / 2;
+          this.stage.style.transformOrigin = '0 0';
+          this.stage.style.transform = `translate(${x}px, ${y}px) scale(${s})`;
+        };
+        fit();
+        window.addEventListener('resize', fit);
+      }
+      show(i) {
+        this.current = Math.max(0, Math.min(i, this.slides.length - 1));
+        this.slides.forEach((sl, idx) => {
+          const on = idx === this.current;
+          sl.classList.toggle('active', on);
+          sl.classList.toggle('visible', on);   // re-triggers .animate-in reveals
+        });
+        this.updateControls();
+      }
+      next() { this.show(this.current + 1); }
+      prev() { this.show(this.current - 1); }
+      // setupKeyboardNav / setupTouchNav / renderControls / updateControls …
+    }
+    new SlidePresentation();
+
+    /* === Inline editing: JS-based hover (NOT CSS ~ sibling) + E key, strip on export === */
+    // editToggle.classList.add('show') on hotzone mouseenter, 400ms grace on leave;
+    // toggle contenteditable on slide text; persist to localStorage; export strips edit state.
   </script>
 
 </body>
 </html>
 ```
+
+## Why fixed-canvas (not clamp reflow)
+
+| Concern | How the stage model handles it |
+|---------|--------------------------------|
+| "Fits every screen" | One `scale()` on the whole 1920×1080 stage — no per-element math, no overflow surprises |
+| Slide switching | `.active`/`.visible` classes toggle `visibility`/`opacity`/`pointer-events` — never `display:none`, so animations re-run and embedded state (videos, inputs) survives |
+| Print / PDF | `@media print` in viewport-base.css lays each slide out at design size, one per page — `scripts/export-pdf.sh` and browser Save-as-PDF both produce clean one-slide-per-page output |
+| Mobile | Stage letterboxes/pillarboxes; content never reflows or cramps |
+| Reduced motion | `prefers-reduced-motion` block in viewport-base.css neutralizes animations |
+
+This only applies to **decks** (slides). The document-style skills (one-pager, proposal, brief, microsite, win-loss-report, etc.) remain scrolling pages and keep their `clamp()`/reflow model — they share the *color/font* presets, not this stage model.

--- a/skills/deck/references/slide-templates.md
+++ b/skills/deck/references/slide-templates.md
@@ -2,9 +2,11 @@
 
 Use these templates for each slide type in the outline. Mix types for visual variety.
 
-**Title Slide:**
+> **Fixed-canvas authoring.** Every `<section class="slide">` lives inside `.deck-stage` and is authored at **1920×1080** (see [html-scaffold.md](html-scaffold.md)). Size content in **px against that canvas**, never `clamp()`/`vw`/`vh`. The semantic classes below (`heading-1`, `body-text`, `slide-inner`, etc.) are defined in the scaffold at authored px sizes. The **first slide** must carry `class="slide slide-title active visible"` so it shows and animates on load; all other slides are just `class="slide"` and become visible as the controller navigates.
+
+**Title Slide (first slide — note `active visible`):**
 ```html
-<section class="slide slide-title" data-slide="0">
+<section class="slide slide-title active visible" data-slide="0">
   <div class="slide-inner flex-center flex-col">
     <span class="pill animate-in">[Category/Tag]</span>
     <h1 class="heading-1 animate-in">[Main Title]</h1>
@@ -147,7 +149,7 @@ Use these templates for each slide type in the outline. Mix types for visual var
   <div class="slide-inner">
     <h2 class="heading-2 animate-in">[Image Title]</h2>
     <div class="image-container mt-md animate-in">
-      <img src="[image-url-or-path]" alt="[Description]" style="max-width: 100%; max-height: 55vh; object-fit: contain;" />
+      <img src="[image-url-or-path]" alt="[Description]" style="max-width: 100%; max-height: 720px; object-fit: contain;" />
     </div>
     <p class="body-text text-secondary animate-in mt-sm">[Caption or context]</p>
   </div>

--- a/skills/deck/references/style-presets.md
+++ b/skills/deck/references/style-presets.md
@@ -4,6 +4,10 @@ Full CSS variable definitions for the 12 style presets available in `/octave:dec
 
 Each preset defines a complete visual system. Apply by copying the `:root` block into the generated HTML.
 
+> **Presets define color, type *family*, radius, and easing — not layout sizes.** For decks, typography and spacing are authored in **px on the 1920×1080 canvas** (see [html-scaffold.md](html-scaffold.md)); the `--pad-x`/`--pad-y` `clamp()` vars below are used by the scrolling document skills (one-pager, proposal, etc.) and are overridden by px padding in decks. The same preset file therefore serves both the fixed-canvas deck and the reflow documents.
+>
+> **Wildcard/custom styles:** the presets are deliberate brand systems (e.g. `octave-brand` purple, `midnight-pro` Inter) and are fine as-is. But when generating a *custom* wildcard preview, follow the no-slop rules in `SKILL.md` — avoid Inter/Roboto, generic purple-on-white, and cookie-cutter layouts.
+
 ---
 
 ## Dark Themes

--- a/skills/deck/references/viewport-base.css
+++ b/skills/deck/references/viewport-base.css
@@ -1,0 +1,133 @@
+/* ===========================================
+   FIXED 16:9 STAGE: MANDATORY BASE STYLES
+   Include this ENTIRE file in every presentation.
+   Slides are authored at 1920×1080 and scaled as a whole.
+   =========================================== */
+
+/* 1. Lock the browser viewport */
+html,
+body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+    background: var(--stage-bg, #000);
+}
+
+/* 2. Full-window deck viewport */
+.deck-viewport {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background: var(--stage-bg, #000);
+}
+
+/* 3. Fixed 16:9 design canvas.
+   JavaScript sets transform: translate(...) scale(...). */
+.deck-stage {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 1920px;
+    height: 1080px;
+    overflow: hidden;
+    transform-origin: 0 0;
+    background: var(--slide-bg, #fff);
+}
+
+/* 4. Slides stack inside the fixed stage.
+   Content must be laid out at 1920×1080, not reflowed per device. */
+.slide {
+    position: absolute;
+    inset: 0;
+    width: 1920px;
+    height: 1080px;
+    overflow: hidden;
+    display: block;
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    background: var(--slide-bg, #fff);
+}
+
+.slide.active,
+.slide.visible {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+    z-index: 1;
+}
+
+/* 5. Keep media inside authored slide bounds */
+img,
+video,
+canvas,
+svg {
+    max-width: 100%;
+    max-height: 100%;
+}
+
+/* 6. Presentation chrome stays outside the slide design system */
+.deck-controls {
+    position: fixed;
+    left: 50%;
+    bottom: 22px;
+    transform: translateX(-50%);
+    z-index: 1000;
+}
+
+/* 7. Print one fixed-size slide per page */
+@media print {
+    html,
+    body {
+        width: 1920px;
+        height: auto;
+        overflow: visible;
+        background: #fff;
+    }
+
+    .deck-viewport {
+        position: static;
+        overflow: visible;
+        background: #fff;
+    }
+
+    .deck-stage {
+        position: static;
+        width: auto;
+        height: auto;
+        transform: none !important;
+        background: none;
+    }
+
+    .slide {
+        position: relative;
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        pointer-events: auto !important;
+        width: 1920px;
+        height: 1080px;
+        break-after: page;
+        page-break-after: always;
+    }
+
+    .slide:last-child {
+        break-after: auto;
+        page-break-after: auto;
+    }
+
+    .deck-controls {
+        display: none !important;
+    }
+}
+
+/* 8. Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.2s !important;
+    }
+}

--- a/skills/meeting-prep/SKILL.md
+++ b/skills/meeting-prep/SKILL.md
@@ -504,7 +504,7 @@ Navigation:
 - Scroll naturally to read through sections
 - Click nav dots on the right edge to jump to sections
 - Click section headers to collapse/expand
-- Print-friendly: Cmd+P / Ctrl+P for clean PDF output
+- PDF (recommended): bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh .octave-meeting-prep/<name>-<date>/<name>.html  — or Cmd+P / Ctrl+P -> Save as PDF
 
 ---
 

--- a/skills/microsite/SKILL.md
+++ b/skills/microsite/SKILL.md
@@ -84,15 +84,18 @@ Your choice:
 **Brand — "Use your company's brand styling?"**
 
 ```
-Should the microsite use your company's brand?
+Whose brand should the microsite reflect?
 
-1. Yes — extract from my website (provide URL)
-2. Yes — I'll provide brand assets (colors, fonts, logo)
-3. No — I'll pick from style presets
-4. Use Octave brand styling
+1. My brand (the sender) — extract from my website (give the URL)
+2. The recipient's brand — mirror the target account's look for maximum ABM personalization (give *their* URL)
+3. I'll provide brand assets directly (colors, fonts, logo)
+4. No brand — pick from style presets
+5. Use Octave brand styling
 
 Your choice:
 ```
+
+> **This choice decides which website we fetch for styling** — your domain (option 1) or the target account's domain (option 2). It's separate from the recipient *context* below, which always personalizes the content regardless of whose brand styles the page.
 
 ### Step 2: Octave Context Gathering
 
@@ -130,11 +133,15 @@ Two layers of brand apply to microsites:
 
 **If user chose brand extraction in Step 1:**
 
-Use the same tiered brand extraction approach as the deck skill:
+Use the same tiered brand extraction approach as the deck skill (see `/octave:deck` Step 3 for full detail):
 
-1. **Tier 1: browser-use** (best quality) — open the website, screenshot, extract computed styles (colors, fonts, logos) via JS eval, confirm with user
-2. **Tier 2: WebFetch** (fallback) — fetch homepage HTML/CSS, parse CSS custom properties, font-family declarations, logo URLs, and meta theme-color
-3. **Tier 3: Manual** (if neither works) — ask user to provide hex colors, font names, and logo files directly
+1. **Tier 1: `get_external_brand_assets`** (first-party, fast) — one call returns brand colors, logo variants, and backdrop images. Sanity-check the result: a strip of varied logos is usually a "trusted by" **customer wall**, not the brand's own logo, and `brandName` can grab a customer — prefer the favicon/nav wordmark and verify against the domain.
+2. **Tier 2: `scrape_website`** (`{ format: "html", includeScreenshot: true }`) — pull the homepage **and one representative page**; read fonts + CSS custom properties from the html, and the **component/layout vocabulary** (button shapes, card radii, spacing, gradients, section patterns) from the screenshot. Microsites especially benefit — the goal is to *look like the sender's site*, not just borrow its colors.
+3. **Tier 3: browser-use** (fallback) — open the site, screenshot, extract computed styles via JS eval.
+4. **Tier 4: WebFetch** (fallback) — parse homepage HTML/CSS for CSS custom properties, font-family, logo URLs, meta theme-color.
+5. **Tier 5: Manual** — ask user for hex colors, font names, and logo files directly.
+
+Confirm the brand config with the user before proceeding.
 
 **If user chose a style preset:**
 
@@ -283,9 +290,10 @@ Style:  [Preset name or "Custom Brand"]
 Size:   [file size]
 
 How to share:
+• Live URL (recommended): bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/deploy.sh .octave-microsites/<company>-<date>/  — deploys to Vercel and returns a public link to drop in your outreach
+• PDF: bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh .octave-microsites/<company>-<date>/<company>-microsite.html  — or Cmd+P / Ctrl+P -> Save as PDF
 • Host on any static file server, S3 bucket, or Netlify drop
 • Or send the HTML file directly as an attachment
-• Best shared as a link in your outreach email
 
 ---
 

--- a/skills/one-pager/SKILL.md
+++ b/skills/one-pager/SKILL.md
@@ -107,7 +107,7 @@ Ask the user:
 How would you like to style the one-pager?
 
 1. Pick from presets — 12 styles from dark executive to light minimal
-2. Use my brand — extract from my website or provide brand assets
+2. Use a brand — mine (the sender) or the recipient's; extract from a website or provide assets
 3. Auto-pick — I'll choose based on the occasion and tone
 4. Surprise me
 
@@ -116,7 +116,7 @@ Your choice:
 
 **Option 1: Preset Picker** -- Show the same preset table from the deck skill (see `/octave:deck` Step 4, Option 2).
 
-**Option 2: Brand Extraction** -- Follow the same brand discovery flow from the deck skill (see `/octave:deck` Step 3). Supports browser-use tier, WebFetch tier, and manual fallback. Confirm brand config with user before proceeding.
+**Option 2: Brand Extraction** -- Follow the same brand discovery flow from the deck skill (see `/octave:deck` Step 3): Tier 1 `get_external_brand_assets` (colors + logo, with a customer-logo sanity check), Tier 2 `scrape_website` with `includeScreenshot` for fonts + components, then browser-use / WebFetch / manual fallbacks. Confirm brand config with user before proceeding.
 
 **Option 3: Auto-Pick** -- Map occasion + tone to recommended presets:
 
@@ -194,7 +194,7 @@ Size:   [file size]
 
 Viewing:
 - Open in any browser -- single scrollable page
-- Print-friendly -- Cmd+P / Ctrl+P for clean printout
+- PDF (recommended): bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh .octave-one-pagers/<name>-<date>/<name>.html  — or Cmd+P / Ctrl+P -> Save as PDF
 - Email as attachment or save as PDF
 
 Customization tips:

--- a/skills/positioning/SKILL.md
+++ b/skills/positioning/SKILL.md
@@ -320,7 +320,7 @@ Navigation:
 - Scroll through all 8 frameworks
 - Sidebar dots on the right track your position
 - Click section headers to collapse/expand
-- Print-friendly: Cmd+P / Ctrl+P for clean PDF
+- PDF (recommended): bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh .octave-positioning/<product>-<date>/positioning-system.html  — or Cmd+P / Ctrl+P -> Save as PDF
 
 ---
 

--- a/skills/proposal/SKILL.md
+++ b/skills/proposal/SKILL.md
@@ -163,7 +163,7 @@ How would you like to style the proposal?
 
 1. Use recommended — [preset name] (best for [audience])
 2. Pick from presets — show me all 12 options
-3. Use my brand — extract from a website or provide brand assets
+3. Use a brand — yours or the customer's; extract from a website or provide assets
 4. Surprise me — auto-pick based on context
 
 Your choice:
@@ -175,7 +175,7 @@ See [style-presets.md](references/style-presets.md) for the full list of 12 styl
 
 Full CSS variable definitions for each preset are in the deck skill's [style-presets.md](../deck/references/style-presets.md).
 
-**Brand extraction is encouraged for proposals.** A proposal that carries the customer's or your own brand colors looks significantly more professional and intentional. Follow the same brand discovery flow as `/octave:deck` Step 3 (browser-use > WebFetch > manual fallback).
+**Brand extraction is encouraged for proposals.** A proposal that carries the customer's or your own brand colors looks significantly more professional and intentional. Follow the same brand discovery flow as `/octave:deck` Step 3: `get_external_brand_assets` (Tier 1: colors + logo, with a customer-logo sanity check) → `scrape_website` with `includeScreenshot` (Tier 2: fonts + components) → browser-use → WebFetch → manual.
 
 ### Step 4: Generate HTML
 
@@ -272,6 +272,9 @@ See [delivery-summary.md](references/delivery-summary.md) for the PROPOSAL READY
 
 ```
 To save as PDF (recommended for sharing):
+
+PDF (recommended): bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh .octave-proposals/<name>-<date>/<name>.html
+  — or use the manual print dialog below:
 
 1. Open the proposal in your browser (already open)
 2. Press Cmd+P (Mac) or Ctrl+P (Windows)

--- a/skills/proposal/references/delivery-summary.md
+++ b/skills/proposal/references/delivery-summary.md
@@ -26,7 +26,7 @@ Included Sections:
 Navigation:
 - Scroll to read — sticky sidebar shows your position
 - Click any TOC item to jump to that section
-- Print: Cmd+P / Ctrl+P — page breaks between sections
+- PDF (recommended): bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh .octave-proposals/<name>-<date>/<name>.html  — or Cmd+P / Ctrl+P -> Save as PDF (page breaks between sections)
 
 ---
 

--- a/skills/win-loss-report/SKILL.md
+++ b/skills/win-loss-report/SKILL.md
@@ -177,7 +177,7 @@ Key Findings:
 Navigation:
 - Scroll to navigate between sections
 - Sidebar dots show your position
-- Print-friendly (Cmd+P / Ctrl+P for PDF export)
+- PDF (recommended): bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh .octave-reports/win-loss-<date>/win-loss-report.html  — or Cmd+P / Ctrl+P -> Save as PDF
 
 ---
 


### PR DESCRIPTION
Updates HTML generation across the visual skills, syncing the deck engine with [frontend-slides](https://github.com/zarazhangrui/frontend-slides) v2.1.0 and improving brand handling.

## What changed

**Deck — fixed-canvas model**
- Migrated from the `clamp()`/`100vh`/scroll-snap reflow to a **fixed 1920×1080 stage scaled as a whole** (`transform: scale()`), so slides fit any screen without overflow.
- Added `references/viewport-base.css` (mandatory base) + `animation-patterns.md`; `SlidePresentation` controller using `.active`/`.visible` (no scroll-snap / nav dots).
- "Show, don't tell" style previews, density intake (speaker-led vs reading-first), inline editing (default), and AI-slop avoidance guidance.

**Export & share scripts (all HTML skills)**
- `scripts/export-pdf.sh` — headless Playwright PDF (one slide/page), with a no-`.slide` full-page fallback so it also works for scrolling documents.
- `scripts/deploy.sh` — Vercel deploy to a public live URL (featured in microsite).
- Wired into deck + one-pager, proposal, microsite, brief, win-loss-report, battlecard-doc, meeting-prep, positioning via `${CLAUDE_PLUGIN_ROOT}`; manual Cmd+P kept as fallback.

**Brand discovery**
- `get_external_brand_assets` is now Tier 1 (colors + logo, with a customer-logo sanity check); `scrape_website` is Tier 2 for fonts + components (pending OCT-2649, gated behind a fallback so it's correct today).
- Added a **"whose brand — sender vs recipient"** fork that decides which website we fetch (e.g. mirror a target account for ABM).

**Versioning**
- Bumped plugin + marketplace to **1.11.0**.

Note: the upstream 34-template "bold pack" was evaluated and deliberately not included (mostly consumer/novelty aesthetics; presets + custom-wildcard cover the need).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
