### PR TITLE
lfgtm: reference list_revisions / get_revision in library + audit skills

### DIFF
--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -57,6 +57,13 @@ Then use `get_entity` for entities that need deeper inspection (qualifying quest
 
 If `--type` is specified, only fetch that type (but still need related types for relationship checks).
 
+**Optional — surface what's changed recently.** When the user is asking about staleness ("what hasn't been touched in a while?", "show me what's been changing"), or you suspect an entity is mid-edit, use the revision tools:
+
+- `list_revisions({ startDate, entityTypes, limit })` — recent edits across the workspace (or filtered by entity type / author). Returns lightweight summaries (no field-level diff).
+- `get_revision({ revisionOId, diffOnly: true })` — full diff for a specific revision when you need to know exactly what changed.
+
+This is especially useful in **CLEANUP MODE** below, where staleness (e.g. competitors not updated in 30+ days) and recent churn (e.g. a persona that was rewritten twice last week) are both audit signals.
+
 ### Step 2: Determine Mode
 
 After gathering the library state, ask the user:
@@ -615,6 +622,7 @@ If the library has 0 proof points AND 0 references, don't just flag it as "missi
 
 - [ ] Entities updated within last 90 days (flag if older)
 - [ ] Competitor info updated within last 30 days (competitive intel goes stale fast)
+- [ ] Use `list_revisions({ startDate, entityTypes })` to see what's actually been edited recently — an entity with an old `updatedAt` but no revision activity is genuinely stale; one with recent revisions is being actively maintained. Use `get_revision({ revisionOId, diffOnly: true })` to inspect a specific change if a revision looks suspicious (e.g. a competitor's strengths were silently rewritten).
 
 #### Duplicate Detection (WARNING)
 

--- a/skills/library/SKILL.md
+++ b/skills/library/SKILL.md
@@ -15,6 +15,7 @@ User runs `/octave:library` with subcommands:
 - `/octave:library show <oId>` - Show full entity details
 - `/octave:library create <type> "<name>"` - Create new entity
 - `/octave:library update <oId>` - Update existing entity
+- `/octave:library history [<oId>]` - Browse revision history across the library or for a single entity
 
 Or natural language like:
 - "Show me all personas"
@@ -486,6 +487,28 @@ User: "Add a competitive displacement Motion Playbook for [Competitor] under our
    })
 ```
 
+### Subcommand: history
+
+Browse the audit trail for library entities — who changed what, when, and what the diff looked like.
+
+**Usage:**
+```
+/octave:library history                          # recent revisions across the workspace
+/octave:library history pe_abc123                # all revisions for one entity
+/octave:library history --type persona           # recent revisions, filtered by entity type
+/octave:library history --since 2026-04-01       # revisions on or after a date
+/octave:library history rv_xyz789 --diff         # full snapshot + diff for one revision
+```
+
+**Actions:**
+- For a list of revisions: use `list_revisions` with any combination of `entityTypes`, `entityOIds`, `startDate`, `endDate`, `authorOId`, `includeRestored`, `limit`, `offset`. The list returns lightweight summaries (revisionOId, entity, action, author, timestamp) — no field-level diff.
+- For a specific revision's full snapshot and diff: use `get_revision({ revisionOId, diffOnly: false })`. Pass `diffOnly: true` to skip the full snapshot and only return the change set.
+
+**Use this when:**
+- The user asks "what changed recently?", "who edited this persona?", "show me the history of this segment", "did anyone touch the library last week?"
+- You suspect an entity was edited out from under an agent's expectations (e.g. a persona's pain points were rewritten and an email agent is now producing odd copy)
+- Auditing — see CLEANUP MODE in `/octave:audit` — wants to know whether stale-looking content is actually stale or was recently revised
+
 ### Legacy playbooks (deprecated)
 
 The legacy `get_playbook`, `list_value_props`, `create_playbook`, `update_playbook`, `add_value_props`, and `update_value_props` tools remain available for backwards compatibility with workspaces still operating on standalone playbooks. New workflows should prefer the Motion / Motion Playbook / Motion ICP tools above; legacy playbook tools should only be used when explicitly working with a workspace that hasn't migrated to Motions.
@@ -506,6 +529,10 @@ The legacy `get_playbook`, `list_value_props`, `create_playbook`, `update_playbo
 - `get_motion_playbook` - Full Motion Playbook details
 - `list_motion_icps` - Persona × segment matrix (Motion ICP cells) for a Motion
 - `find_motion_icp` - Full Motion ICP cell narrative (Target ICP overview, Operating landscape, Strategic narrative, Pains and consequences, Benefits and impacts, Methodology, References) + Learning Loop learnings
+
+### Revision / Audit Trail Operations
+- `list_revisions` - List entity revisions across the workspace; filter by `entityTypes`, `entityOIds`, `startDate`, `endDate`, `authorOId`, `includeRestored`, with `limit` / `offset` paging. Returns lightweight summaries (no field-level diff).
+- `get_revision` - Full snapshot + diff for a single revision; pass `diffOnly: true` to skip the snapshot and return only the change set.
 
 ### Write Operations
 - `create_entity` - Create new library entity (calls generate endpoints)


### PR DESCRIPTION
## Summary

[octave-app#6354](https://github.com/octavehq/octave-app/pull/6354) (OCT-2654) added entity-revision MCP tools `list_revisions` and `get_revision`. This wires them into the two skills where revision history is most useful:

- **`/octave:library`** — new `history` subcommand for browsing revisions across the workspace, by entity, by type, or by date range; plus a dedicated `Revision / Audit Trail Operations` section in the MCP tools index.
- **`/octave:audit`** — Step 1 (Gather Library State) now notes the optional revision lookups for "what's been changing?" questions, and the `Freshness Checks` list calls out distinguishing genuinely-stale entities from recently-edited ones.

The public REST mirror of these tools (`/api/v2/revision/list`, `/api/v2/revision/get`) is being added in [octave-app#6357](https://github.com/octavehq/octave-app/pull/6357) and surfaced in the docs in [docs#36](https://github.com/octavehq/docs/pull/36) — this PR is the third leg of the rollout.

Linear: [OCT-2656](https://linear.app/octave/issue/OCT-2656)

## Test plan

- [ ] Re-run `/octave:audit` in CLEANUP MODE and confirm the freshness check now references `list_revisions` / `get_revision` as next-step actions
- [ ] Run `/octave:library history` and `/octave:library history pe_<oId>` against a workspace and confirm the subcommand maps onto `list_revisions` / `get_revision` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
