### PR TITLE
Merge list_all_entities into list_entities (slim by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,14 +529,13 @@ Authentication is handled via OAuth at the MCP server level. No API keys are sto
 
 ## MCP Tools
 
-The plugin uses the single Octave MCP server you configure (e.g. `octave-acme`). Call tools by name (e.g. `verify_connection()`, `get_entity(...)`, `list_all_entities(...)`).
+The plugin uses the single Octave MCP server you configure (e.g. `octave-acme`). Call tools by name (e.g. `verify_connection()`, `get_entity(...)`, `list_entities(...)`).
 
 ### Connection
 - `verify_connection` - Verify workspace connection and authentication status
 
 ### Library Read
-- `list_all_entities` - Quick list with basic fields
-- `list_entities` - Detailed list with pagination
+- `list_entities` - List entities by type; slim rows by default, `includeDetails: true` for full data, plus `search`, `all`, and pagination
 - `get_entity` - Full entity details
 - `list_revisions` - List version history for library entities
 - `get_revision` - Get a specific historical revision of an entity
@@ -570,7 +569,7 @@ Still available for workspaces operating on legacy standalone playbooks, but Mot
 ### Configuration
 - `list_writing_styles` - List all writing style configurations
 
-> Brand voices are retrieved via the generic entity tools: `list_all_entities({ entityType: "brand_voice" })` or `list_entities({ entityType: "brand_voice" })`.
+> Brand voices are retrieved via the generic entity tool: `list_entities({ entityType: "brand_voice" })`.
 
 ### Resources
 - `list_resources` - List global resources (documents, websites) with filtering

--- a/agents/octave-assistant.md
+++ b/agents/octave-assistant.md
@@ -28,7 +28,7 @@ For the full entity taxonomy — entity types, oId prefixes, field-by-field stru
 You have access to the full Octave MCP server. Tools grouped by capability (see the plugin README for the per-tool reference):
 
 - **Connection** — `verify_connection`
-- **Library read** — `list_all_entities`, `list_entities`, `get_entity`, `search_knowledge_base`, `ask_octave` (natural-language questions over the typed knowledge graph), revision history via `list_revisions` / `get_revision`, `list_writing_styles`. There is no `list_brand_voices` tool — use `list_all_entities({ entityType: "brand_voice" })`.
+- **Library read** — `list_entities`, `get_entity`, `search_knowledge_base`, `ask_octave` (natural-language questions over the typed knowledge graph), revision history via `list_revisions` / `get_revision`, `list_writing_styles`. There is no `list_brand_voices` tool — use `list_entities({ entityType: "brand_voice" })`.
 - **Library write** — `create_entity` / `update_entity` / `delete_entity`, and `link_entities_to_offering` (drives which entities appear in a Motion's matrix)
 - **Motions** — `list_motions` / `get_motion` plus create/update/delete, `list_motion_playbooks` / `get_motion_playbook` plus create/update/delete, `list_motion_icps`, and `find_motion_icp` (full persona × segment narrative plus Learning Loop learnings)
 - **Research** — `find_person` / `find_company`, `find_similar_people` / `find_similar_companies`, `enrich_person` / `enrich_company`, `qualify_person` / `qualify_company`, `resolve_profile_from_email` / `resolve_email_from_profile`, `scrape_website`, `deep_web_research`, `get_external_brand_assets` / `get_external_brand_logo`

--- a/agents/pmm-strategist.md
+++ b/agents/pmm-strategist.md
@@ -33,7 +33,7 @@ You have access to the full Octave MCP server. Your primary tools:
 
 ### Strategy & Analysis
 - `search_knowledge_base` - Find existing positioning, messaging, competitive intel
-- `list_all_entities` / `get_entity` - Review all library entities (offerings, personas, segments, competitors, objections, alternatives, buying triggers)
+- `list_entities` / `get_entity` - Review all library entities (offerings, personas, segments, competitors, objections, alternatives, buying triggers)
 - `list_motions` / `get_motion` / `list_motion_playbooks` / `get_motion_playbook` - Review Motions and their narrative angles
 - `list_motion_icps` / `find_motion_icp` - Pull the structured narrative (Target ICP overview, Operating landscape, Strategic narrative, Pains and consequences, Benefits and impacts, Methodology, References) for any persona × segment cell; include learnings for what's resonating
 - `list_findings` - Surface what's resonating (and what's not) from real conversations
@@ -42,7 +42,7 @@ You have access to the full Octave MCP server. Your primary tools:
 ### Content Creation
 - `generate_content` - Generate messaging frameworks, positioning, content
 - `generate_email` - Create email sequences grounded in the relevant Motion ICP
-- `list_all_entities` (entityType: "brand_voice") / `list_writing_styles` - Ensure brand consistency
+- `list_entities` (entityType: "brand_voice") / `list_writing_styles` - Ensure brand consistency
 
 ### Library Management
 - `create_entity` / `update_entity` - Create and refine library entities (personas, segments, competitors, objections, etc.)

--- a/agents/revenue-strategist.md
+++ b/agents/revenue-strategist.md
@@ -51,7 +51,7 @@ You have access to the full Octave MCP server. Your primary tools:
 - `generate_call_prep` - Meeting preparation for critical calls (uses Motion ICP narrative)
 
 ### Library Management
-- `list_all_entities` / `get_entity` - Review ICP definitions, personas, segments, objections
+- `list_entities` / `get_entity` - Review ICP definitions, personas, segments, objections
 - `list_motions` / `get_motion` / `list_motion_playbooks` / `get_motion_playbook` - Review Motions and their narrative angles
 - `find_motion_icp` - Pull the rep-facing narrative for any persona × segment intersection (Strategic narrative, Pains and consequences, Benefits and impacts, Methodology, References)
 - `update_entity` / `update_motion` / `update_motion_playbook` - Refine strategy based on field data

--- a/skills/abm/SKILL.md
+++ b/skills/abm/SKILL.md
@@ -58,7 +58,7 @@ qualify_company({
 ```
 # Find decision makers and influencers
 # Use persona titles from library to guide search
-list_all_entities({ entityType: "persona" })
+list_entities({ entityType: "persona" })
 
 # Search for stakeholders matching each persona
 find_person({
@@ -166,7 +166,7 @@ generate_email({
 - `find_company` - Company lookup by name
 
 ### Library Context
-- `list_all_entities` (persona) - Get persona definitions for stakeholder matching
+- `list_entities` (persona) - Get persona definitions for stakeholder matching
 - `list_motions` - List all Motions in the workspace
 - `list_motion_icps` - List Motion ICP cells (persona × segment intersections) for a Motion
 - `find_motion_icp` - Full Motion ICP cell narrative (Target ICP overview, Operating landscape, Strategic narrative, Pains and consequences, Benefits and impacts, Methodology, References) plus Learning Loop learnings

--- a/skills/ads/SKILL.md
+++ b/skills/ads/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[describe the campaign target and angle]"
 
 Generate platform-ready ad campaign plans grounded in your Octave library intelligence. Creates one ad set per persona or ICP, with creative variants generated from real prospect language extracted from calls and emails. Source cards are persisted to disk so `/octave:ads-resonance` can later map performance back to the exact derivation chain behind each headline.
 
-**MCP Server**: This skill requires the Octave MCP server. Look for available MCP tools that match the Octave tool names (e.g., `list_all_entities`, `list_findings`, `search_knowledge_base`, `get_entity`). The MCP server prefix varies by workspace — it may be `{octave_mcp}__`, `mcp__octave_myworkspace__`, or another name. If multiple Octave-like MCP servers are available and you're unsure which to use, ask the user which workspace to target.
+**MCP Server**: This skill requires the Octave MCP server. Look for available MCP tools that match the Octave tool names (e.g., `list_entities`, `list_findings`, `search_knowledge_base`, `get_entity`). The MCP server prefix varies by workspace — it may be `{octave_mcp}__`, `mcp__octave_myworkspace__`, or another name. If multiple Octave-like MCP servers are available and you're unsure which to use, ask the user which workspace to target.
 
 ---
 
@@ -118,7 +118,7 @@ Ask about voice and tone for the creative:
 
 If they choose "Use my Octave brand voice", fetch it in Step 2:
 ```
-→ {octave_mcp}__list_all_entities(entityType: "brand_voice")
+→ {octave_mcp}__list_entities(entityType: "brand_voice")
 → {octave_mcp}__get_entity(oId: "{brand_voice_oId}")  // fetch full voice guidelines (tone, word choice, style rules)
 ```
 
@@ -139,10 +139,10 @@ Based on the ad set structure chosen in Step 1, fetch the relevant data from Oct
 
 ```
 If ICP or Persona mode:
-  → {octave_mcp}__list_all_entities(entityType: "persona")
+  → {octave_mcp}__list_entities(entityType: "persona")
 
 If ICP or Segment mode:
-  → {octave_mcp}__list_all_entities(entityType: "segment")
+  → {octave_mcp}__list_entities(entityType: "segment")
 ```
 
 Present the list to the user and ask them to confirm which ones to build ad sets for, or select "all."
@@ -152,10 +152,10 @@ Present the list to the user and ask them to confirm which ones to build ad sets
 Fetch all use cases and competitors — these inform creative themes and negative targeting.
 
 ```
-→ {octave_mcp}__list_all_entities(entityType: "use_case")
-→ {octave_mcp}__list_all_entities(entityType: "competitor")
-→ {octave_mcp}__list_all_entities(entityType: "proof_point")
-→ {octave_mcp}__list_all_entities(entityType: "reference")
+→ {octave_mcp}__list_entities(entityType: "use_case")
+→ {octave_mcp}__list_entities(entityType: "competitor")
+→ {octave_mcp}__list_entities(entityType: "proof_point")
+→ {octave_mcp}__list_entities(entityType: "reference")
 ```
 
 ### 2C: Fetch Field Intelligence

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -35,22 +35,22 @@ When the user runs `/octave:audit`:
 
 ### Step 1: Gather Library State
 
-**Resolve Octave MCP server first:** The Octave MCP server provides tools like `verify_connection`, `get_entity`, `list_all_entities`. From your tool list, get the server name.
+**Resolve Octave MCP server first:** The Octave MCP server provides tools like `verify_connection`, `get_entity`, `list_entities`. From your tool list, get the server name.
 
 **Fetch entities using MCP tools:**
 
 ```
-1. list_all_entities({ entityType: "persona" })
-2. list_all_entities({ entityType: "product" })
-3. list_all_entities({ entityType: "segment" })
-4. list_all_entities({ entityType: "use_case" })
-5. list_all_entities({ entityType: "competitor" })
-6. list_all_entities({ entityType: "alternative" })
-7. list_all_entities({ entityType: "buying_trigger" })
-8. list_all_entities({ entityType: "objection" })
-9. list_all_entities({ entityType: "proof_point" })
-10. list_all_entities({ entityType: "reference" })
-11. list_all_entities({ entityType: "playbook" }) — legacy standalone playbooks, if any remain
+1. list_entities({ entityType: "persona" })
+2. list_entities({ entityType: "product" })
+3. list_entities({ entityType: "segment" })
+4. list_entities({ entityType: "use_case" })
+5. list_entities({ entityType: "competitor" })
+6. list_entities({ entityType: "alternative" })
+7. list_entities({ entityType: "buying_trigger" })
+8. list_entities({ entityType: "objection" })
+9. list_entities({ entityType: "proof_point" })
+10. list_entities({ entityType: "reference" })
+11. list_entities({ entityType: "playbook" }) — legacy standalone playbooks, if any remain
 12. list_motions() — all Motions in workspace
 13. For each Motion: list_motion_icps({ motionOId }) — Motion ICP cell state
 ```
@@ -110,7 +110,7 @@ For cleanup mode, render the report with [cleanup-report-template.md](references
 ## MCP Tools Used
 
 ### Read Operations
-- `list_all_entities` - Get all entities of each type (quick scan)
+- `list_entities` - Get all entities of each type (quick scan)
 - `get_entity` - Get full details for specific entities (qualifying questions, field data, links)
 - `get_playbook` - Get a legacy standalone playbook with its linked personas, segments, and value props (migration mode only)
 - `list_value_props` - Read value props on a legacy playbook (migration mode only)

--- a/skills/audit/references/migration-mode.md
+++ b/skills/audit/references/migration-mode.md
@@ -14,7 +14,7 @@ Add to the standard library fetch:
 ```
 - list_motions() — all Motions in workspace
 - For each Motion: list_motion_icps({ motionOId }) — Motion ICP cell state
-- list_all_entities({ entityType: "playbook" }) — all standalone playbooks
+- list_entities({ entityType: "playbook" }) — all standalone playbooks
 - get_playbook({ oId }) for each standalone playbook — linked personas, segments, value props, type
 - list_agents() — all saved agents with their configurations
 ```

--- a/skills/battlecard/SKILL.md
+++ b/skills/battlecard/SKILL.md
@@ -42,7 +42,7 @@ If no competitor specified, list available competitors:
 
 ```
 # Get all competitors
-list_all_entities({ entityType: "competitor" })
+list_entities({ entityType: "competitor" })
 ```
 
 Present:
@@ -129,7 +129,7 @@ list_events({
 })
 
 # Get product details for comparison
-list_all_entities({ entityType: "product" })
+list_entities({ entityType: "product" })
 get_entity({ oId: "<product_oId>" })
 ```
 
@@ -221,8 +221,8 @@ For the full interactive mode selector, use `/octave:generate`.
 ## MCP Tools Used
 
 ### Competitive Intelligence
-- `list_all_entities` (competitor) - List all competitors
-- `list_entities` (competitor / product / proof_point / reference) - Full entity data
+- `list_entities` (competitor) - List competitors (slim; add `all: true` for the full set)
+- `list_entities` (competitor / product / proof_point / reference) with `includeDetails: true` - Full entity data
 - `get_entity` - Get competitor or product details
 - `search_knowledge_base` - Find competitive positioning, proof points
 - `list_findings` - Real conversation mentions and objections

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -59,42 +59,42 @@ Use MCP tools based on brainstorm type:
 
 **For Campaigns:**
 ```
-- list_all_entities({ entityType: "segment" })
-- list_all_entities({ entityType: "persona" })
+- list_entities({ entityType: "segment" })
+- list_entities({ entityType: "persona" })
 - list_motions()
-- list_all_entities({ entityType: "use_case" })
+- list_entities({ entityType: "use_case" })
 ```
 
 **For Motion Playbook Concepts:**
 ```
-- list_all_entities({ entityType: "segment" })
-- list_all_entities({ entityType: "persona" })
-- list_all_entities({ entityType: "product" })
-- list_all_entities({ entityType: "use_case" })
+- list_entities({ entityType: "segment" })
+- list_entities({ entityType: "persona" })
+- list_entities({ entityType: "product" })
+- list_entities({ entityType: "use_case" })
 - list_motions()                                  # See existing Motions
 - list_motion_playbooks({ motionOId: "<motion_oId>" })  # See existing Default + Custom Motion Playbooks
 ```
 
 **For Lead Magnets:**
 ```
-- list_all_entities({ entityType: "persona" })
-- list_all_entities({ entityType: "use_case" })
-- list_all_entities({ entityType: "proof_point" })
+- list_entities({ entityType: "persona" })
+- list_entities({ entityType: "use_case" })
+- list_entities({ entityType: "proof_point" })
 - search_knowledge_base({ query: "pain points challenges problems" })
 ```
 
 **For CTAs & Offers:**
 ```
-- list_all_entities({ entityType: "persona" })
-- list_all_entities({ entityType: "product" })
-- list_all_entities({ entityType: "proof_point" })
+- list_entities({ entityType: "persona" })
+- list_entities({ entityType: "product" })
+- list_entities({ entityType: "proof_point" })
 ```
 
 **For Growth Experiments:**
 ```
 - list_motions()
-- list_all_entities({ entityType: "segment" })
-- list_all_entities({ entityType: "persona" })
+- list_entities({ entityType: "segment" })
+- list_entities({ entityType: "persona" })
 ```
 
 ### Step 3: Ask Scoping Questions (Optional)
@@ -203,7 +203,7 @@ Your choice:
 ## MCP Tools Used
 
 ### Read Operations
-- `list_all_entities` - Get entities for context
+- `list_entities` - Get entities for context
 - `get_entity` - Deep dive on specific entities
 - `list_motions` - See existing Motions
 - `list_motion_playbooks` - Understand existing Motion Playbook coverage (Default + Custom) on a Motion

--- a/skills/brief/references/tool-reference.md
+++ b/skills/brief/references/tool-reference.md
@@ -37,7 +37,7 @@ Start with company enrichment and contact discovery:
 | Motion ICP matrix | `list_motion_icps({ motionOId })` | See the persona × segment matrix under a Motion |
 | Motion ICP narrative | `find_motion_icp({ motionIcpOId, includeLearnings: true })` | Full Target ICP overview, Strategic narrative, Pains and consequences, Benefits and impacts, Methodology, References, plus Learning Loop learnings for the target cell |
 | Custom Motion Playbook details | `get_motion_playbook({ motionPlaybookOId })` | When a Custom Motion Playbook (Thematic / Milestone / Account / Competitive) layers on the relevant Motion |
-| All competitors | `list_all_entities({ entityType: "competitor" })` | Quick scan of competitive landscape |
+| All competitors | `list_entities({ entityType: "competitor" })` | Quick scan of competitive landscape |
 | Competitor details | `get_entity({ oId })` | Deep dive on a specific relevant competitor |
 | Proof points | `list_entities({ entityType: "proof_point" })` | Full proof points for the evidence section |
 | References | `list_entities({ entityType: "reference" })` | Customer references for social proof |

--- a/skills/campaign/SKILL.md
+++ b/skills/campaign/SKILL.md
@@ -119,7 +119,7 @@ search_knowledge_base({ query: "<campaign topic>", entityTypes: ["proof_point", 
 get_entity({ oId: "<competitor_oId>" })
 
 # Get brand voice
-list_all_entities(entityType: "brand_voice")
+list_entities(entityType: "brand_voice")
 
 # Get writing style
 list_writing_styles()
@@ -275,7 +275,7 @@ See [generation-modes.md](../shared/generation-modes.md) for the default generat
 ## MCP Tools Used
 
 ### Library Context
-- `list_all_entities` - List available personas, products
+- `list_entities` - List available personas, products
 - `get_entity` - Get full entity details
 - `list_motions` - List all Motions in the workspace
 - `list_motion_icps` - List Motion ICP cells (persona × segment intersections) for a Motion
@@ -283,7 +283,7 @@ See [generation-modes.md](../shared/generation-modes.md) for the default generat
 - `list_motion_playbooks` - List Default + Custom Motion Playbooks under a Motion (when a Thematic / Milestone / Account / Competitive angle applies)
 - `get_motion_playbook` - Full details for a Motion Playbook
 - `search_knowledge_base` - Find proof points, references, messaging
-- `list_all_entities` (entityType: "brand_voice") - Get brand voice for consistency
+- `list_entities` (entityType: "brand_voice") - Get brand voice for consistency
 - `list_writing_styles` - Get writing style guidelines
 
 ### Content Generation

--- a/skills/deal-coach/SKILL.md
+++ b/skills/deal-coach/SKILL.md
@@ -168,9 +168,9 @@ list_findings({
 list_events({
   filters: { companyDomains: ["<domain>"] }
 })
-list_all_entities({ entityType: "persona" })
-list_all_entities({ entityType: "competitor" })
-list_all_entities({ entityType: "proofPoint" })
+list_entities({ entityType: "persona" })
+list_entities({ entityType: "competitor" })
+list_entities({ entityType: "proofPoint" })
 ```
 
 **Motion ICP (after enrichment / persona / segment inference):**
@@ -193,9 +193,9 @@ If any tool call fails, note the gap and continue. Coach with available data and
 For generic mode, gather library-level data only:
 
 ```
-list_all_entities({ entityType: "persona" })
-list_all_entities({ entityType: "competitor" })
-list_all_entities({ entityType: "proofPoint" })
+list_entities({ entityType: "persona" })
+list_entities({ entityType: "competitor" })
+list_entities({ entityType: "proofPoint" })
 ```
 
 Then load the Default Motion Playbook narrative for the most relevant Motion:
@@ -406,7 +406,7 @@ This directory should be in `.gitignore`.
 |------|---------|
 | `search_knowledge_base` | Find matching guides and research |
 | `search_resources` | Find relevant resources (docs, presentations) |
-| `list_all_entities` | List personas, competitors, proof points, references |
+| `list_entities` | List personas, competitors, proof points, references |
 | `list_findings` | Objections, pain points, competitor mentions from conversations |
 | `list_events` | Deal history, stage changes, activity timeline |
 

--- a/skills/deal-coach/references/coaching-agents.md
+++ b/skills/deal-coach/references/coaching-agents.md
@@ -48,8 +48,8 @@ Map the seller's Octave library data to Resonate coaching outputs:
 | Output Field | Octave Source | How to Map |
 |-------------|---------------|------------|
 | Buyer Mindset | `enrich_company` → company profile, industry; `find_crm_records` → deal stage; `list_findings` → pain points | Synthesize buyer's likely awareness level, trigger, and constraints from available data |
-| Value Propositions | `find_motion_icp` → Pains and consequences, Strategic narrative; `list_all_entities` → proof points (benchmarks) | Select props that validate pain without prescribing; use benchmarks to show you understand the problem |
-| Talking Points | `find_motion_icp` → Methodology (discovery questions); `list_findings` → pain points; `list_all_entities` → personas | Generate discovery questions that go wide, deep, and high; tailor to the persona's language and level |
+| Value Propositions | `find_motion_icp` → Pains and consequences, Strategic narrative; `list_entities` → proof points (benchmarks) | Select props that validate pain without prescribing; use benchmarks to show you understand the problem |
+| Talking Points | `find_motion_icp` → Methodology (discovery questions); `list_findings` → pain points; `list_entities` → personas | Generate discovery questions that go wide, deep, and high; tailor to the persona's language and level |
 
 ### Example Coaching Interaction
 
@@ -92,8 +92,8 @@ You are equal parts provocative strategist and positioning expert. You understan
 | Output Field | Octave Source | How to Map |
 |-------------|---------------|------------|
 | Buyer Mindset | `list_findings` → status quo signals, competitor mentions; `find_crm_records` → stage; `find_crm_activities` → engagement pattern | Assess: is the buyer still defending status quo, or actively evaluating? |
-| Value Propositions | `find_motion_icp` → Strategic narrative, Benefits and impacts; `list_all_entities` → competitors (for differentiated value assessment) | Cross-reference: what's unique in the Motion ICP narrative AND missing from competitor capabilities AND important to this buyer? |
-| Talking Points | `enrich_company` → industry trends (The Shift); `list_findings` → pain points (Status Quo Gaps); `list_all_entities` → proof points; `find_motion_icp` → Strategic narrative + Benefits and impacts (Value Framing + The Reframe) | Build the 3-beat Case for Change from deal data; generate Value Framing translations from the Motion ICP narrative |
+| Value Propositions | `find_motion_icp` → Strategic narrative, Benefits and impacts; `list_entities` → competitors (for differentiated value assessment) | Cross-reference: what's unique in the Motion ICP narrative AND missing from competitor capabilities AND important to this buyer? |
+| Talking Points | `enrich_company` → industry trends (The Shift); `list_findings` → pain points (Status Quo Gaps); `list_entities` → proof points; `find_motion_icp` → Strategic narrative + Benefits and impacts (Value Framing + The Reframe) | Build the 3-beat Case for Change from deal data; generate Value Framing translations from the Motion ICP narrative |
 
 ### Example Coaching Interaction
 
@@ -140,8 +140,8 @@ You are part business case architect and part executive communication coach. You
 | Output Field | Octave Source | How to Map |
 |-------------|---------------|------------|
 | Buyer Mindset | `find_crm_records` → deal stage, amount, close date; `find_crm_activities` → exec engagement; `generate_crm_context` → deal narrative | Map decision process, budget status, champion engagement level, and timeline pressure |
-| Value Propositions | `list_all_entities` → proof points (quantified); `find_motion_icp` → Benefits and impacts (ROI data, outcomes); `enrich_company` → strategic initiatives | Select props with specific metrics; align to company's stated priorities |
-| Talking Points | `find_crm_records` → deal amount + timeline (for cost of delay); `list_all_entities` → personas (for stakeholder mapping); `find_motion_icp` → Strategic narrative + Benefits and impacts (executive messaging); `list_all_entities` → proof points (for benchmarks) | Build Value Discovery questions, Value Proof models, Why Now Case (both dimensions), and champion talk track |
+| Value Propositions | `list_entities` → proof points (quantified); `find_motion_icp` → Benefits and impacts (ROI data, outcomes); `enrich_company` → strategic initiatives | Select props with specific metrics; align to company's stated priorities |
+| Talking Points | `find_crm_records` → deal amount + timeline (for cost of delay); `list_entities` → personas (for stakeholder mapping); `find_motion_icp` → Strategic narrative + Benefits and impacts (executive messaging); `list_entities` → proof points (for benchmarks) | Build Value Discovery questions, Value Proof models, Why Now Case (both dimensions), and champion talk track |
 
 ### Example Coaching Interaction
 
@@ -189,7 +189,7 @@ You are a negotiation coach who has advised on deals from $50K to $50M. You beli
 | Output Field | Octave Source | How to Map |
 |-------------|---------------|------------|
 | Value Anchor | Prior Compel business case + `find_crm_records` → deal amount | Reference the quantified value already established |
-| Competitive Alternatives | `list_all_entities` → competitors | Know the buyer's BATNA |
+| Competitive Alternatives | `list_entities` → competitors | Know the buyer's BATNA |
 | Concession Inventory | `find_motion_icp` → Methodology / pricing notes; library `product` / pricing entities | Know what can be traded and its cost |
 | Relationship Context | `find_crm_activities` + `list_findings` → sentiment | Gauge relationship strength and leverage |
 
@@ -222,7 +222,7 @@ You see every objection as a diagnostic signal. You never "handle" objections in
 |-------------|---------------|------------|
 | Objection Context | `list_findings` → objections | Match finding objections to stage gaps |
 | Resolution Framework | `frameworks.md` → relevant stage | Pull Talking Points for the identified gap stage |
-| Supporting Evidence | `list_all_entities` → proof points | Counter objections with quantified data |
+| Supporting Evidence | `list_entities` → proof points | Counter objections with quantified data |
 | Motion ICP Response | `find_motion_icp` → Pains and consequences, Methodology (objection handling); `get_motion_playbook` → Custom Motion Playbook objection content | Combine stage coaching with offering-specific responses |
 
 ### Example Coaching Interaction

--- a/skills/deal-coach/references/messaging-narratives.md
+++ b/skills/deal-coach/references/messaging-narratives.md
@@ -47,7 +47,7 @@ Build the mindset assessment from:
 | Octave Source | Selection Logic |
 |---------------|----------------|
 | `find_motion_icp` → Pains and consequences, Strategic narrative | Select props that mirror the buyer's stated pain — validate, don't prescribe |
-| `list_all_entities` → proof points (benchmarks) | Use industry benchmarks to show "we understand this problem at scale" |
+| `list_entities` → proof points (benchmarks) | Use industry benchmarks to show "we understand this problem at scale" |
 | `search_knowledge_base` → relevant research | Pull research that expands the problem scope (supports going wide) |
 
 **Selection filter:** At Resonate, only surface value props that validate pain or expand problem scope. Exclude solution-focused, ROI-focused, or competitive props.
@@ -56,9 +56,9 @@ Build the mindset assessment from:
 
 | Discovery Principle | Octave Source | Grounded Output Pattern |
 |-------------------|---------------|------------------------|
-| Go wide | `list_all_entities` → personas; `list_findings` → stakeholder mentions | "Who else is affected by [pain from findings]? How does this look from [persona's] perspective?" |
+| Go wide | `list_entities` → personas; `list_findings` → stakeholder mentions | "Who else is affected by [pain from findings]? How does this look from [persona's] perspective?" |
 | Go deep | `find_motion_icp` → Methodology (discovery questions); `list_findings` → pain points | "You mentioned [pain from findings]. In our experience with [industry from enrichment] companies, that usually traces back to [root cause from Motion ICP narrative]. Is that what you're seeing?" |
-| Go high | `list_all_entities` → proof points (metrics); `find_motion_icp` → Benefits and impacts (business impact messaging) | "When [similar company from proof points] faced this, it was affecting [business metric]. How is that showing up at the leadership level for you?" |
+| Go high | `list_entities` → proof points (metrics); `find_motion_icp` → Benefits and impacts (business impact messaging) | "When [similar company from proof points] faced this, it was affecting [business metric]. How is that showing up at the leadership level for you?" |
 
 **Example grounded talking point:**
 
@@ -87,8 +87,8 @@ Build the mindset assessment from:
 | Octave Source | Selection Logic |
 |---------------|----------------|
 | `find_motion_icp` → Strategic narrative (differentiators, positioning) | Core: what's unique in the Motion ICP narrative that matters to this buyer |
-| `list_all_entities` → competitors | Filter: cross-reference to find differentiated value (unique + important + competitor can't match) |
-| `list_all_entities` → proof points (results) | Proof points: specific customer results that make differentiation credible |
+| `list_entities` → competitors | Filter: cross-reference to find differentiated value (unique + important + competitor can't match) |
+| `list_entities` → proof points (results) | Proof points: specific customer results that make differentiation credible |
 | `find_motion_icp` → Benefits and impacts (outcomes) | Future state vision: what the changed state looks like |
 
 **Selection filter:** At Elevate, prioritize props that represent differentiated value. Deprioritize parity capabilities and irrelevant uniqueness.
@@ -100,8 +100,8 @@ Build the Case for Change by chaining Octave data across three narrative beats. 
 | Narrative Beat | Octave Source | Grounded Output Pattern |
 |---------------|---------------|------------------------|
 | **The Shift** | `enrich_company` → industry trends, news; `search_knowledge_base` → market research; `list_findings` → pain points; `find_motion_icp` → Operating landscape, Pains and consequences (problem framing) | "I've been talking to [industry from enrichment] leaders, and [specific trend from knowledge base] is creating pressure. Teams still doing [current approach from findings] built it for a world where [old assumption from Motion ICP Operating landscape]. Under [trend], that approach breaks because [specific flaw]..." |
-| **The Stakes** | `list_all_entities` → proof points (metrics); `find_motion_icp` → Strategic narrative (positioning, blind spots) | "Companies that didn't adapt saw [quantified impact from proof points]. And here's what most people miss: this isn't about [surface problem from findings]. It's about [reframed need from Motion ICP Strategic narrative]..." |
-| **The Possibility** | `find_motion_icp` → Benefits and impacts (outcomes); `list_all_entities` → proof points (results) | "Customers who made this shift saw [specific outcome from proof points]..." |
+| **The Stakes** | `list_entities` → proof points (metrics); `find_motion_icp` → Strategic narrative (positioning, blind spots) | "Companies that didn't adapt saw [quantified impact from proof points]. And here's what most people miss: this isn't about [surface problem from findings]. It's about [reframed need from Motion ICP Strategic narrative]..." |
+| **The Possibility** | `find_motion_icp` → Benefits and impacts (outcomes); `list_entities` → proof points (results) | "Customers who made this shift saw [specific outcome from proof points]..." |
 
 For Value Framing:
 ```
@@ -130,16 +130,16 @@ Question: "[Question that highlights the gap] — it matters because [connected 
 | `find_crm_records` → deal amount, stage, close date | Deal position and financial scope | Frame the business case relative to deal size |
 | `find_crm_activities` → exec engagement | Whether economic buyer is in play | If no exec engagement → champion enablement is priority |
 | `generate_crm_context` → synthesized narrative | Full deal story | Understand decision dynamics, competing priorities |
-| `list_all_entities` → personas (champion) | Champion's role and influence | Assess: can they sell internally, or do they need heavy coaching? |
+| `list_entities` → personas (champion) | Champion's role and influence | Assess: can they sell internally, or do they need heavy coaching? |
 
 ### Value Propositions Grounding
 
 | Octave Source | Selection Logic |
 |---------------|----------------|
-| `list_all_entities` → proof points (quantified) | Core: props with specific ROI metrics from similar customers |
+| `list_entities` → proof points (quantified) | Core: props with specific ROI metrics from similar customers |
 | `enrich_company` → strategic initiatives | Alignment: props that map to the buyer's stated priorities |
 | `find_motion_icp` → Benefits and impacts (ROI data, outcomes) | Financial: props with quantifiable outcomes for business case |
-| `list_all_entities` → personas | Stakeholder mapping: tailor props per decision maker's priorities |
+| `list_entities` → personas | Stakeholder mapping: tailor props per decision maker's priorities |
 
 **Selection filter:** At Compel, only surface props with quantified outcomes or strategic alignment. Exclude discovery-stage props and generic positioning.
 
@@ -150,16 +150,16 @@ Question: "[Question that highlights the gap] — it matters because [connected 
 | Phase | Octave Source | Grounded Output Pattern |
 |-------|---------------|------------------------|
 | **Value Discovery** | `find_crm_records` → deal amount; `enrich_company` → revenue, headcount | "Based on [company size from enrichment], if [metric] improves by [benchmark from proof points]..." |
-| **Value Proof — Before/After** | `list_findings` → pain points; `find_motion_icp` → Benefits and impacts; `list_all_entities` → use cases | "Today your team spends [current effort from findings] on [process]. In the new model, [future state from Motion ICP Benefits and impacts]..." |
-| **Value Proof — Quantify** | `list_all_entities` → proof points (quantified) | "Based on what [similar customer from proof points] achieved — [metric improvement] — that translates to [dollar impact]..." |
+| **Value Proof — Before/After** | `list_findings` → pain points; `find_motion_icp` → Benefits and impacts; `list_entities` → use cases | "Today your team spends [current effort from findings] on [process]. In the new model, [future state from Motion ICP Benefits and impacts]..." |
+| **Value Proof — Quantify** | `list_entities` → proof points (quantified) | "Based on what [similar customer from proof points] achieved — [metric improvement] — that translates to [dollar impact]..." |
 | **Value Chain** | `find_motion_icp` → Benefits and impacts + Strategic narrative (full chain) | "[Capability] → [workflow improvement] → [business outcome] → [$financial_result] — mapped through [buyer's org from personas]" |
 
 #### Why Now Case
 
 | Dimension | Octave Source | Grounded Output Pattern |
 |-----------|---------------|------------------------|
-| Business urgency | `enrich_company` → strategic initiatives; `generate_crm_context`; `find_crm_records` → timeline; `list_all_entities` → proof points | "Your company prioritized [initiative from enrichment]. This supports it. Every month of delay costs [monthly_burn from benchmarks]. Over [timeline from CRM], that's [total]..." |
-| Personal urgency | `list_all_entities` → personas (champion); `find_crm_activities` → interactions | "As [champion's role from persona], delivering this initiative gives you visibility on [strategic priority]..." |
+| Business urgency | `enrich_company` → strategic initiatives; `generate_crm_context`; `find_crm_records` → timeline; `list_entities` → proof points | "Your company prioritized [initiative from enrichment]. This supports it. Every month of delay costs [monthly_burn from benchmarks]. Over [timeline from CRM], that's [total]..." |
+| Personal urgency | `list_entities` → personas (champion); `find_crm_activities` → interactions | "As [champion's role from persona], delivering this initiative gives you visibility on [strategic priority]..." |
 
 #### Champion Enablement (Executive Decision Kit)
 

--- a/skills/deal-coach/references/mode-roleplay.md
+++ b/skills/deal-coach/references/mode-roleplay.md
@@ -36,7 +36,7 @@ AskUserQuestion({
 })
 ```
 
-If in specific-deal mode, identify the buyer persona from entities gathered in Step 2 of the skill. If generic, let the user choose from available personas (dynamically populated from `list_all_entities({ entityType: "persona" })`, up to 4 options with title/role descriptions).
+If in specific-deal mode, identify the buyer persona from entities gathered in Step 2 of the skill. If generic, let the user choose from available personas (dynamically populated from `list_entities({ entityType: "persona" })`, up to 4 options with title/role descriptions).
 
 ## RP-2: Load Stage-Specific Intelligence
 

--- a/skills/deck/SKILL.md
+++ b/skills/deck/SKILL.md
@@ -409,7 +409,7 @@ Common research, library, signals, and generation tools: see [../shared/octave-r
 - `get_external_brand_assets` — Scrape a URL for brand colors, logo variants, backdrop images, brand name (Tier 1 brand extraction)
 - `get_external_brand_logo` — Single best logo URL for a domain
 - `scrape_website` — Fetch a page as markdown/html with an optional screenshot (`{ format, includeScreenshot }`) — used to read components/typography for brand emulation (Tier 2)
-- `list_all_entities` (entityType: "brand_voice") — Available brand voices in workspace
+- `list_entities` (entityType: "brand_voice") — Available brand voices in workspace
 - `list_writing_styles` — Available writing styles in workspace
 
 ## Error Handling

--- a/skills/deck/references/tool-reference.md
+++ b/skills/deck/references/tool-reference.md
@@ -31,12 +31,12 @@ Pull from the library to ground the deck in your actual GTM data:
 
 | What you need | Tool | When to use |
 |---------------|------|-------------|
-| Personas | `list_all_entities({ entityType: "persona" })` | Quick scan of all personas |
+| Personas | `list_entities({ entityType: "persona" })` | Quick scan of all personas |
 | Persona details | `list_entities({ entityType: "persona" })` | Full persona data — pain points, priorities, messaging |
-| Segments | `list_all_entities({ entityType: "segment" })` | Quick scan of market segments |
-| Competitors | `list_all_entities({ entityType: "competitor" })` | Quick scan of competitive landscape |
-| Products | `list_all_entities({ entityType: "product" })` | Quick scan of product capabilities |
-| Use cases | `list_all_entities({ entityType: "use_case" })` | When deck covers how customers use the product |
+| Segments | `list_entities({ entityType: "segment" })` | Quick scan of market segments |
+| Competitors | `list_entities({ entityType: "competitor" })` | Quick scan of competitive landscape |
+| Products | `list_entities({ entityType: "product" })` | Quick scan of product capabilities |
+| Use cases | `list_entities({ entityType: "use_case" })` | When deck covers how customers use the product |
 | Entity details | `get_entity({ oId })` | Deep dive on any specific entity found above |
 | Positioning by topic | `search_knowledge_base({ query: "<topic>", entityTypes: ["product"] })` | When you have a concept and need relevant positioning |
 | Motions | `list_motions()` | Available Motions to ground the deck in |
@@ -54,7 +54,7 @@ Focus on the specific competitor(s) and evidence from real deals:
 
 | What you need | Tool | When to use |
 |---------------|------|-------------|
-| All competitors | `list_all_entities({ entityType: "competitor" })` | Quick scan of all competitors |
+| All competitors | `list_entities({ entityType: "competitor" })` | Quick scan of all competitors |
 | Competitor full data | `list_entities({ entityType: "competitor" })` | Full competitor profiles — strengths, weaknesses, positioning |
 | Competitor deep dive | `get_entity({ oId })` | Everything about one specific competitor |
 | Competitive positioning | `search_knowledge_base({ query: "<competitor> differentiation", entityTypes: ["competitor"] })` | When you have a concept — "how do we beat them on security?" |

--- a/skills/enablement/SKILL.md
+++ b/skills/enablement/SKILL.md
@@ -109,10 +109,10 @@ search_knowledge_base({
 })
 
 # Get competitors for context
-list_all_entities({ entityType: "competitor" })
+list_entities({ entityType: "competitor" })
 
 # Get brand voice
-list_all_entities(entityType: "brand_voice")
+list_entities(entityType: "brand_voice")
 ```
 
 ### Step 3: Generate Content Type
@@ -179,7 +179,7 @@ See [generation-modes.md](../shared/generation-modes.md) for the default generat
 ## MCP Tools Used
 
 ### Library Context
-- `list_all_entities` - All entity types for comprehensive coverage
+- `list_entities` - All entity types for comprehensive coverage
 - `get_entity` - Full entity details
 - `list_motions` - List Motions in the workspace
 - `list_motion_playbooks` - List Motion Playbooks under a Motion (Default + Custom)
@@ -195,7 +195,7 @@ See [generation-modes.md](../shared/generation-modes.md) for the default generat
 
 ### Content Generation
 - `generate_content` - All enablement content types
-- `list_all_entities` (entityType: "brand_voice") - Brand voice consistency
+- `list_entities` (entityType: "brand_voice") - Brand voice consistency
 
 ## Error Handling
 

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -259,7 +259,7 @@ search_knowledge_base({ query: "<topic> <persona>", entityTypes: ["persona"] })
 get_entity({ oId: "<persona_oId>" })
 
 # Get product details
-list_all_entities({ entityType: "product" })
+list_entities({ entityType: "product" })
 get_entity({ oId: "<product_oId>" })
 
 # Find the matching Motion + Motion ICP cell for this topic and persona
@@ -271,7 +271,7 @@ find_motion_icp({ motionIcpOId: "<motion_icp_oId>", includeLearnings: true })
 search_knowledge_base({ query: "<topic>", entityTypes: ["proof_point", "reference"] })
 
 # Get brand voice
-list_all_entities(entityType: "brand_voice")
+list_entities(entityType: "brand_voice")
 
 # Get competitive positioning if relevant
 search_knowledge_base({ query: "<topic>", entityTypes: ["competitor"] })
@@ -368,7 +368,7 @@ Your choice:
 - `find_motion_icp` - Get full Motion ICP cell narrative (Target ICP overview, Strategic narrative, Pains and consequences, Benefits and impacts, Methodology, References) plus Learning Loop learnings
 - `list_motion_playbooks` - List Default + Custom Motion Playbooks under a Motion (when a Thematic / Milestone / Account / Competitive angle applies)
 - `get_motion_playbook` - Full details for a Motion Playbook
-- `list_all_entities` (entityType: "brand_voice") - Get brand voice for consistency
+- `list_entities` (entityType: "brand_voice") - Get brand voice for consistency
 
 ### Octave Generation
 - `generate_email` - Email sequence generation (Octave Default mode)

--- a/skills/icp-refine/SKILL.md
+++ b/skills/icp-refine/SKILL.md
@@ -46,18 +46,18 @@ Starting analysis...
 
 ```
 # Get current segments (this IS the ICP definition)
-list_all_entities({ entityType: "segment" })
+list_entities({ entityType: "segment" })
 
 # Get full segment details
 get_entity({ oId: "<segment_oId>" })  // for each segment
 
 # Get current personas
-list_all_entities({ entityType: "persona" })
+list_entities({ entityType: "persona" })
 get_entity({ oId: "<persona_oId>" })  // for key personas
 
 # Get products/services (what we're selling)
-list_all_entities({ entityType: "product" })
-list_all_entities({ entityType: "service" })
+list_entities({ entityType: "product" })
+list_entities({ entityType: "service" })
 ```
 
 ### Step 3: Analyze Deal Outcomes
@@ -184,7 +184,7 @@ What would you like to do next?
 ## MCP Tools Used
 
 ### Library Context
-- `list_all_entities` - Segments, personas, products
+- `list_entities` - Segments, personas, products
 - `get_entity` - Full entity details for ICP definition
 
 ### Deal Analytics

--- a/skills/launch/SKILL.md
+++ b/skills/launch/SKILL.md
@@ -71,7 +71,7 @@ Tell me about the launch:
 get_entity({ oId: "<product_oId>" })
 
 # Get all personas (to prioritize which audiences to target)
-list_all_entities({ entityType: "persona" })
+list_entities({ entityType: "persona" })
 get_entity({ oId: "<primary_persona_oId>" })
 
 # Get the relevant Motion(s) and Motion ICP cells for this offering
@@ -98,7 +98,7 @@ search_knowledge_base({
 })
 
 # Get brand voice
-list_all_entities(entityType: "brand_voice")
+list_entities(entityType: "brand_voice")
 ```
 
 ### Step 3: Generate Launch Plan
@@ -252,10 +252,10 @@ See [generation-modes.md](../shared/generation-modes.md) for the default generat
 ## MCP Tools Used
 
 ### Library Context
-- `list_all_entities` - List products, personas, use cases
+- `list_entities` - List products, personas, use cases
 - `get_entity` - Full entity details
 - `search_knowledge_base` - Proof points, references, competitive intel
-- `list_all_entities` (entityType: "brand_voice") - Brand voice consistency
+- `list_entities` (entityType: "brand_voice") - Brand voice consistency
 
 ### Motions
 - `list_motions` - Motions for the offering

--- a/skills/library/SKILL.md
+++ b/skills/library/SKILL.md
@@ -48,7 +48,7 @@ List entities of a specific type.
 ```
 
 **Actions:**
-- For library entities: use `list_all_entities` for quick overview (default), or `list_entities` with pagination for detailed view (--detailed flag)
+- For library entities: use `list_entities` for a quick slim overview (default), or `list_entities` with `includeDetails: true` for the detailed view (--detailed flag)
 - For Motions: use `list_motions`
 - For Motion Playbooks under a Motion: use `list_motion_playbooks({ motionOId })` — returns the Default Motion Playbook plus any Custom Motion Playbooks
 - For Motion ICP cells (the persona × segment matrix) under a Motion: use `list_motion_icps({ motionOId })`
@@ -203,11 +203,10 @@ The legacy `get_playbook`, `list_value_props`, `create_playbook`, `update_playbo
 
 ## MCP Tools Used
 
-**Important:** Call MCP tools by name (e.g. `get_entity`, `update_entity`, `list_all_entities`).
+**Important:** Call MCP tools by name (e.g. `get_entity`, `update_entity`, `list_entities`).
 
 ### Read Operations
-- `list_all_entities` - Quick list with basic fields (default for list)
-- `list_entities` - Detailed list with pagination (for --detailed flag)
+- `list_entities` - List entities by type; slim rows by default, `includeDetails: true` for full data (--detailed flag), plus `search`, `all`, and pagination
 - `get_entity` - Full entity details
 - `search_knowledge_base` - Semantic search
 

--- a/skills/meeting-prep/references/tool-reference.md
+++ b/skills/meeting-prep/references/tool-reference.md
@@ -47,7 +47,7 @@ Grounding starts here. Before anything names a person or states a "fact," confir
 | References | `list_entities({ entityType: "reference" })` | Customer references with full details |
 | Topic-matched proof | `search_knowledge_base({ query: "<industry> <use case> results", entityTypes: ["proof_point", "reference"] })` | Find proof relevant to *their* specific situation |
 | Known objections | `list_entities({ entityType: "objection" })` | Likely objections + grounded counters |
-| Competitors (scan) | `list_all_entities({ entityType: "competitor" })` | Who's in the landscape |
+| Competitors (scan) | `list_entities({ entityType: "competitor" })` | Who's in the landscape |
 | Competitor deep-dive | `get_entity({ oId })` / `get_competitive_insights({ ... })` | Where they win, where we win, the one differentiator that matters here |
 
 ## 2e. Deal state & conversation history (for the Snapshot)

--- a/skills/messaging/SKILL.md
+++ b/skills/messaging/SKILL.md
@@ -66,11 +66,11 @@ Your choice:
 
 ```
 # Get all core entities for messaging context
-list_all_entities({ entityType: "product" })
-list_all_entities({ entityType: "persona" })
-list_all_entities({ entityType: "segment" })
-list_all_entities({ entityType: "use_case" })
-list_all_entities({ entityType: "competitor" })
+list_entities({ entityType: "product" })
+list_entities({ entityType: "persona" })
+list_entities({ entityType: "segment" })
+list_entities({ entityType: "use_case" })
+list_entities({ entityType: "competitor" })
 
 # Get full product details
 get_entity({ oId: "<product_oId>" })
@@ -93,7 +93,7 @@ search_knowledge_base({
 })
 
 # Get brand voice
-list_all_entities(entityType: "brand_voice")
+list_entities(entityType: "brand_voice")
 
 # Get conversation insights for what resonates
 list_findings({
@@ -165,10 +165,10 @@ update_entity({
 ## MCP Tools Used
 
 ### Library Context
-- `list_all_entities` - List products, personas, segments, use cases, competitors
+- `list_entities` - List products, personas, segments, use cases, competitors
 - `get_entity` - Get full entity details
 - `search_knowledge_base` - Find proof points, references, competitive intel
-- `list_all_entities` (entityType: "brand_voice") - Brand voice for tone consistency
+- `list_entities` (entityType: "brand_voice") - Brand voice for tone consistency
 - `list_findings` - What resonates in real conversations
 
 ### Motions

--- a/skills/microsite/SKILL.md
+++ b/skills/microsite/SKILL.md
@@ -301,7 +301,7 @@ Common research, library, signals, and generation tools: see [../shared/octave-r
 
 ### Brand & Style
 - `get_external_brand_assets` / `get_external_brand_logo` / `scrape_website` — Brand extraction (Tiers 1-2)
-- `list_all_entities` (entityType: "brand_voice") - Available brand voices in workspace
+- `list_entities` (entityType: "brand_voice") - Available brand voices in workspace
 - `list_writing_styles` - Available writing styles in workspace
 
 ## Error Handling

--- a/skills/microsite/references/tool-reference.md
+++ b/skills/microsite/references/tool-reference.md
@@ -12,7 +12,7 @@ Start with enrichment and qualification — this drives the personalization that
 | Motion ICP cell narrative | `find_motion_icp({ personaOId, segmentOId, includeLearnings: true })` | Always — once qualification names the matched persona × segment, fetch the cell directly. If multiple cells come back (several playbooks cover the slot), prefer the one on the DEFAULT-narrative playbook unless the chosen angle matches a specialized one |
 | Persona × segment matrix | `list_motion_icps({ motionOId })` | Only when browsing — the matrix can run to hundreds of paginated cells, so don't scan it to find one cell; use the filtered `find_motion_icp` call above instead |
 | Custom Motion Playbooks | `list_motion_playbooks({ motionOId })` + `get_motion_playbook` | Pull any Thematic / Milestone / Account / Competitive angles layered on the Motion |
-| Brand voice | `list_all_entities(entityType: "brand_voice")` | Always — consistent tone across the microsite |
+| Brand voice | `list_entities(entityType: "brand_voice")` | Always — consistent tone across the microsite |
 
 ---
 
@@ -47,7 +47,7 @@ When the angle is competitive displacement:
 
 | What you need | Tool | When to use |
 |---------------|------|-------------|
-| All competitors | `list_all_entities({ entityType: "competitor" })` | Quick scan of competitive landscape |
+| All competitors | `list_entities({ entityType: "competitor" })` | Quick scan of competitive landscape |
 | Competitor details | `get_entity({ oId })` | Deep dive on the specific competitor they likely use |
 | Competitive positioning | `search_knowledge_base({ query: "<competitor> differentiation", entityTypes: ["competitor"] })` | Messaging angles for competitive deals |
 | Competitive Motion Playbook | `list_motion_playbooks({ motionOId })` then `get_motion_playbook` on any `COMPETITIVE` narrative-type playbook | Pull a dedicated competitive Custom Motion Playbook if one exists for the relevant competitor |
@@ -71,6 +71,6 @@ When the angle is tied to a recent event or news:
 
 | What you need | Tool | When to use |
 |---------------|------|-------------|
-| Products | `list_all_entities({ entityType: "product" })` | When you need product capabilities for the solution section |
-| Use cases | `list_all_entities({ entityType: "use_case" })` | When you want to show relevant use cases |
+| Products | `list_entities({ entityType: "product" })` | When you need product capabilities for the solution section |
+| Use cases | `list_entities({ entityType: "use_case" })` | When you want to show relevant use cases |
 | Synthesized prep | `generate_call_prep({ companyDomain })` | When you want a comprehensive brief to work from |

--- a/skills/one-pager/SKILL.md
+++ b/skills/one-pager/SKILL.md
@@ -227,7 +227,7 @@ Common research, library, signals, and generation tools: see [../shared/octave-r
 
 ### Brand & Style
 - `get_external_brand_assets` / `get_external_brand_logo` / `scrape_website` — Brand extraction (Tiers 1-2)
-- `list_all_entities` (entityType: "brand_voice") - Available brand voices in workspace
+- `list_entities` (entityType: "brand_voice") - Available brand voices in workspace
 - `list_writing_styles` - Available writing styles in workspace
 
 ## Error Handling

--- a/skills/one-pager/references/tool-reference.md
+++ b/skills/one-pager/references/tool-reference.md
@@ -36,9 +36,9 @@ When the target is a segment description rather than a specific company:
 | Motion ICP cells for segment | `list_motion_icps({ motionOId })` | Identify cells where this segment is the segment side of the persona × segment intersection |
 | Motion ICP cell narrative | `find_motion_icp({ motionIcpOId, includeLearnings: true })` | Full per-cell narrative for the segment-specific buyer |
 | Personas | `list_entities({ entityType: "persona" })` | Understand who the typical buyer is in this segment |
-| Segments | `list_all_entities({ entityType: "segment" })` | Quick scan to match the description to a defined segment |
+| Segments | `list_entities({ entityType: "segment" })` | Quick scan to match the description to a defined segment |
 | Proof points | `list_entities({ entityType: "proof_point" })` | Fetch proof points relevant to this segment |
 | References | `list_entities({ entityType: "reference" })` | Customer references in this segment |
 | Products | `list_entities({ entityType: "product" })` | Product capabilities relevant to segment needs |
-| Use cases | `list_all_entities({ entityType: "use_case" })` | Use cases that resonate with this segment |
+| Use cases | `list_entities({ entityType: "use_case" })` | Use cases that resonate with this segment |
 | Uploaded resources | `search_resources({ query: "<segment topic>" })` | Relevant uploaded collateral |

--- a/skills/pmm/SKILL.md
+++ b/skills/pmm/SKILL.md
@@ -177,7 +177,7 @@ Use MCP tools to gather library context:
 
 ```
 # Always get brand voice
-list_all_entities(entityType: "brand_voice")
+list_entities(entityType: "brand_voice")
 
 # Get product info
 get_entity({ oId: "<product_oId>" })
@@ -261,7 +261,7 @@ Which format?
 Always check for brand voices and apply:
 
 ```
-list_all_entities(entityType: "brand_voice")
+list_entities(entityType: "brand_voice")
 ```
 
 If multiple voices exist, ask:
@@ -282,8 +282,8 @@ See [generation-modes.md](../shared/generation-modes.md) for the default generat
 ## MCP Tools Used
 
 ### Library Context
-- `list_all_entities` (entityType: "brand_voice") - Get available brand voices
-- `list_all_entities` - List products, personas, etc.
+- `list_entities` (entityType: "brand_voice") - Get available brand voices
+- `list_entities` - List products, personas, etc.
 - `get_entity` - Get full entity details
 - `search_knowledge_base` - Find relevant messaging, proof points
 

--- a/skills/positioning/SKILL.md
+++ b/skills/positioning/SKILL.md
@@ -109,12 +109,12 @@ Every section needs data from the library. Gather it all up front:
 
 | What you need | Tool | Sections that use it |
 |---------------|------|---------------------|
-| All products | `list_all_entities({ entityType: "product" })` | All 8 |
+| All products | `list_entities({ entityType: "product" })` | All 8 |
 | Product deep dive | `get_entity({ oId: "<product_oId>" })` | All 8 |
 | All personas | `list_entities({ entityType: "persona" })` | 1, 3, 4, 5, 7, 8 |
 | All segments | `list_entities({ entityType: "segment" })` | 1, 3 |
 | All use cases | `list_entities({ entityType: "use_case" })` | 1, 3, 6, 7 |
-| All competitors | `list_all_entities({ entityType: "competitor" })` | 2, 3, 6 |
+| All competitors | `list_entities({ entityType: "competitor" })` | 2, 3, 6 |
 | Competitor details | `get_entity({ oId })` | 3, 6 |
 | All Motions | `list_motions()` | 1, 2, 4, 5, 8 |
 | Motion Playbooks under a Motion | `list_motion_playbooks({ motionOId })` | 1, 2, 4, 5, 8 |
@@ -123,7 +123,7 @@ Every section needs data from the library. Gather it all up front:
 | Motion ICP cell narrative | `find_motion_icp({ motionIcpOId, includeLearnings: true })` | 1, 2, 4, 5, 8 |
 | Proof points | `list_entities({ entityType: "proof_point" })` | 2, 3, 5 |
 | References | `list_entities({ entityType: "reference" })` | 2, 3 |
-| Brand voice | `list_all_entities(entityType: "brand_voice")` | 8 (homepage tone) |
+| Brand voice | `list_entities(entityType: "brand_voice")` | 8 (homepage tone) |
 | Competitive positioning | `search_knowledge_base({ query: "<product> differentiation competitive advantage", entityTypes: ["competitor"] })` | 2, 3, 6 |
 | What resonates | `list_findings({ query: "value propositions positive reactions resonated", startDate: "<90 days ago>", eventFilters: { sentiments: ["POSITIVE"] } })` | 2, 5 |
 | What falls flat | `list_findings({ query: "objections pushback concerns", startDate: "<90 days ago>", eventFilters: { sentiments: ["NEGATIVE"] } })` | 3, 5 |
@@ -359,7 +359,7 @@ update_motion_playbook({
 Common research, library, signals, and generation tools: see [../shared/octave-research-toolkit.md](../shared/octave-research-toolkit.md). Positioning-specific additions:
 
 - `list_findings` with sentiment filters — What resonates (positive) and what falls flat (negative) in real conversations
-- `list_all_entities` (entityType: "brand_voice") — Brand voice for homepage messaging tone
+- `list_entities` (entityType: "brand_voice") — Brand voice for homepage messaging tone
 - `get_workspace_company` — Resolve the sender's own company for brand styling
 
 ### Library Updates (Post-Generation)

--- a/skills/proposal/SKILL.md
+++ b/skills/proposal/SKILL.md
@@ -268,7 +268,7 @@ Common research, library, signals, and generation tools: see [../shared/octave-r
 
 ### Brand & Style
 - `get_external_brand_assets` / `get_external_brand_logo` / `scrape_website` — Brand extraction (Tiers 1-2)
-- `list_all_entities` (entityType: "brand_voice") — Available brand voices in workspace
+- `list_entities` (entityType: "brand_voice") — Available brand voices in workspace
 - `list_writing_styles` — Available writing styles in workspace
 
 ## Error Handling

--- a/skills/qual-doctor/SKILL.md
+++ b/skills/qual-doctor/SKILL.md
@@ -107,9 +107,9 @@ Dynamically build the options list from the agent's active sections only — do 
 #### 1e: Identify Target Entities + Determine Tuning Mode
 
 For each selected section, list the entities in the library:
-- Product/Offering → `list_all_entities({ entityType: "product" })`
-- Persona → `list_all_entities({ entityType: "persona" })`
-- Segment → `list_all_entities({ entityType: "segment" })`
+- Product/Offering → `list_entities({ entityType: "product" })`
+- Persona → `list_entities({ entityType: "persona" })`
+- Segment → `list_entities({ entityType: "segment" })`
 - Motion → `list_motions()` (then `list_motion_icps({ motionOId })` to see the persona × segment cells the agent matches against)
 
 **Determine tuning mode based on entity count:**
@@ -434,7 +434,7 @@ See [cost-reference.md](references/cost-reference.md) for the credits-per-run co
 - `verify_connection` — workspace check
 - `list_agents` (QUALIFY_COMPANY + QUALIFY_PERSON) — find qual agents
 - `get_agent` — full agent config (sections, model, strategy)
-- `list_all_entities` — list entities by type
+- `list_entities` — list entities by type
 - `get_entity` — full entity with qualifying questions + description
 - `find_company` / `find_similar_companies` — find test case companies
 - `find_person` / `find_similar_people` — find test case people

--- a/skills/repurpose/SKILL.md
+++ b/skills/repurpose/SKILL.md
@@ -75,7 +75,7 @@ Great! Now let's define how to repurpose this content.
 WHO is this for?
 (Select a persona, segment, or describe the audience)
 
-1. [List personas from library via list_all_entities]
+1. [List personas from library via list_entities]
 2. [List segments from library]
 3. Describe a custom audience
 
@@ -127,7 +127,7 @@ list_motion_icps({ motionOId: "<motion_oId>" })
 find_motion_icp({ motionIcpOId: "<motion_icp_oId>", includeLearnings: true })
 
 # Get brand voice if adjusting tone
-list_all_entities(entityType: "brand_voice")
+list_entities(entityType: "brand_voice")
 
 # Get writing style if specified
 list_writing_styles()
@@ -153,7 +153,7 @@ find_motion_icp({ motionIcpOId: "<motion_icp_oId>", includeLearnings: true })
 **For Format/Channel Changes:**
 ```
 # Get brand voice guidelines
-list_all_entities(entityType: "brand_voice")
+list_entities(entityType: "brand_voice")
 
 # Get writing style for target format
 search_knowledge_base({
@@ -288,8 +288,8 @@ See [common-scenarios.md](references/common-scenarios.md) for the four common re
 ## MCP Tools Used
 
 ### Read Operations
-- `list_all_entities` - Get available personas and segments
-- `list_all_entities` (entityType: "brand_voice") - Get available brand voice configurations
+- `list_entities` - Get available personas and segments
+- `list_entities` (entityType: "brand_voice") - Get available brand voice configurations
 - `list_writing_styles` - Get available writing style configurations
 - `get_entity` - Get full details for persona and segment entities by oId
 - `list_motions` - List Motions in the workspace

--- a/skills/shared/entity-model.md
+++ b/skills/shared/entity-model.md
@@ -2,6 +2,15 @@
 
 The single source of truth for Octave entity types, their `entityType` values, and their oId prefixes. Skills that list, create, update, or audit library entities should use these names and prefixes consistently.
 
+## Fetching entities
+
+`list_entities` is the single tool for listing any type. It returns **slim rows** (oId, name, description) by default for cheap discovery — start there and escalate only when a step needs more:
+
+- `search: "<name>"` — filter by name/description (resolve an entity by name)
+- `all: true` — return every match in one response instead of paginating
+- `includeDetails: true` — include each entity's full body (narrow with `search` or a small page first)
+- `get_entity({ oId })` — full detail for a single entity once you have its oId
+
 ## Library Entities
 
 | Entity type | `entityType` value | oId prefix | Notes |

--- a/skills/shared/octave-research-toolkit.md
+++ b/skills/shared/octave-research-toolkit.md
@@ -6,7 +6,7 @@ Shared reference for the Octave document and deck skills: how to choose between 
 
 | Tool | Purpose | Use when... |
 |------|---------|-------------|
-| `list_all_entities({ entityType })` | Fetch all entities of a type (minimal fields) | You want a quick inventory — "show me all our personas" |
+| `list_entities({ entityType })` | Fetch all entities of a type (minimal fields) | You want a quick inventory — "show me all our personas" |
 | `list_entities({ entityType })` | Fetch entities with full data (paginated) | You need the actual content — "get full proof point details" |
 | `get_entity({ oId })` | Deep dive on one specific entity | You found something relevant and need the complete picture |
 | `search_knowledge_base({ query })` | Semantic search across library + resources | You have a concept or question — "how do we position for healthcare?" |
@@ -64,7 +64,7 @@ This turns a generic "here's our product" asset into "here's what we heard from 
 
 | What you need | Tool | When to use |
 |---------------|------|-------------|
-| Competitor scan | `list_all_entities({ entityType: "competitor" })` | Who's in the landscape |
+| Competitor scan | `list_entities({ entityType: "competitor" })` | Who's in the landscape |
 | Competitor deep dive | `get_entity({ oId })` | Full strengths, weaknesses, positioning |
 | Competitive positioning | `search_knowledge_base({ query: "<competitor> differentiation", entityTypes: ["competitor"] })` | Messaging angles when a competitor is in the deal |
 | Competitive Motion Playbook | `list_motion_playbooks({ motionOId })` filtered by `narrativeType === "COMPETITIVE"` + `get_motion_playbook` | A dedicated competitive narrative layered on the Motion |
@@ -84,7 +84,7 @@ This turns a generic "here's our product" asset into "here's what we heard from 
 |---------------|------|-------------|
 | Positioning/messaging content | `generate_content({ instructions, customContext })` | Synthesize gathered library data into structured content |
 | Email content | `generate_email({ ... })` | Follow-up email copy |
-| Brand voices | `list_all_entities({ entityType: "brand_voice" })` | Available brand voices in the workspace |
+| Brand voices | `list_entities({ entityType: "brand_voice" })` | Available brand voices in the workspace |
 | Writing styles | `list_writing_styles()` | Available writing styles in the workspace |
 
 ## Standard error handling

--- a/skills/shared/roleplay-mechanics.md
+++ b/skills/shared/roleplay-mechanics.md
@@ -12,7 +12,7 @@ Collect three choices before starting (via `AskUserQuestion` when not provided a
 
 1. **Scenario** — what conversation is being practiced. The invoking skill supplies the options (e.g., discovery call, objection handling, demo pitch, competitive displacement; or a single coaching stage vs. a full journey simulation).
 2. **Difficulty** — how much resistance the buyer gives (see tiers below).
-3. **Buyer persona** — dynamically populated from `list_all_entities({ entityType: "persona" })`. Present up to 4 personas with title and key concern. If the invoking context already fixes the persona (e.g., a specific deal's stakeholder), skip this question.
+3. **Buyer persona** — dynamically populated from `list_entities({ entityType: "persona" })`. Present up to 4 personas with title and key concern. If the invoking context already fixes the persona (e.g., a specific deal's stakeholder), skip this question.
 
 ### 2. Difficulty Tiers
 

--- a/skills/signals/SKILL.md
+++ b/skills/signals/SKILL.md
@@ -75,7 +75,7 @@ Bucket the returned findings by type yourself (objections, competitors, value pr
 
 **D. Library Context (for gap detection)**
 ```
-list_all_entities({})
+list_entities({})
 ```
 
 ### Step 2: Analyze and Prioritize Signals
@@ -191,7 +191,7 @@ Suggest the appropriate follow-up skill based on signal type:
 - `get_event_detail` - Drill into specific events
 
 ### Library Context
-- `list_all_entities` - Full library inventory for gap detection
+- `list_entities` - Full library inventory for gap detection
 - `list_motions` - List Motions in the workspace
 - `list_motion_playbooks` - List Motion Playbooks under a Motion
 - `list_motion_icps` - List Motion ICP cells under a Motion

--- a/skills/train/SKILL.md
+++ b/skills/train/SKILL.md
@@ -90,7 +90,7 @@ AskUserQuestion({
 If no persona specified, present available personas:
 ```
 # Get personas from library
-list_all_entities({ entityType: "persona" })
+list_entities({ entityType: "persona" })
 ```
 
 Ask:
@@ -130,7 +130,7 @@ list_findings({
 })
 
 # Get product details
-list_all_entities({ entityType: "product" })
+list_entities({ entityType: "product" })
 get_entity({ oId: "<product_oId>" })
 
 # Get competitor details (for competitive scenarios)
@@ -202,7 +202,7 @@ AskUserQuestion({
 ```
 # Load based on topic
 # For Personas:
-list_all_entities({ entityType: "persona" })
+list_entities({ entityType: "persona" })
 get_entity({ oId: "<persona_oId>" })  // for each persona
 
 # For Objections:
@@ -215,15 +215,15 @@ list_motion_icps({ motionOId: "<motion_oId>" })
 find_motion_icp({ motionIcpOId: "<motion_icp_oId>", includeLearnings: true })
 
 # For Competitive:
-list_all_entities({ entityType: "competitor" })
+list_entities({ entityType: "competitor" })
 get_entity({ oId: "<competitor_oId>" })  // for each competitor
 
 # For Full GTM:
-list_all_entities({ entityType: "persona" })
-list_all_entities({ entityType: "product" })
-list_all_entities({ entityType: "competitor" })
+list_entities({ entityType: "persona" })
+list_entities({ entityType: "product" })
+list_entities({ entityType: "competitor" })
 search_knowledge_base({ query: "value propositions proof points" })
-list_all_entities({ entityType: "use_case" })
+list_entities({ entityType: "use_case" })
 ```
 
 #### Step Q-3: Run the Quiz
@@ -292,7 +292,7 @@ See [guided-learning-template.md](references/guided-learning-template.md) for th
 ## MCP Tools Used
 
 ### Library Context
-- `list_all_entities` - List personas, products, competitors, use cases
+- `list_entities` - List personas, products, competitors, use cases
 - `get_entity` - Full entity details (persona pain points, competitor weaknesses, etc.)
 - `list_motions` - List Motions in the workspace
 - `list_motion_playbooks` - List Motion Playbooks under a Motion (Default + Custom)

--- a/skills/wins-losses/SKILL.md
+++ b/skills/wins-losses/SKILL.md
@@ -220,7 +220,7 @@ Apply approved library updates via `update_entity` (competitors, personas, segme
 
 ### Library Context
 - `get_entity` - Competitor, persona details
-- `list_all_entities` / `list_entities` - Competitor, segment, persona, proof point inventories
+- `list_entities` - Competitor, segment, persona, proof point inventories
 - `list_motions` - List Motions in the workspace
 - `list_motion_icps` - List Motion ICP cells under a Motion
 - `find_motion_icp` - Motion ICP narrative + Learning Loop learnings

--- a/skills/wins-losses/references/html-report.md
+++ b/skills/wins-losses/references/html-report.md
@@ -35,7 +35,7 @@ Do you want to filter the analysis?
 Your choice:
 ```
 
-If competitor or segment is selected, use `list_all_entities({ entityType: "competitor" })` or `list_all_entities({ entityType: "segment" })` to show available options.
+If competitor or segment is selected, use `list_entities({ entityType: "competitor" })` or `list_entities({ entityType: "segment" })` to show available options.
 
 **Depth — "How detailed?"**
 

--- a/skills/wins-losses/references/tool-reference.md
+++ b/skills/wins-losses/references/tool-reference.md
@@ -4,7 +4,7 @@
 
 | Tool | Purpose | Use when... |
 |------|---------|-------------|
-| `list_all_entities({ entityType })` | Fetch all entities of a type (minimal fields) | You want a quick inventory — "show me all competitors" |
+| `list_entities({ entityType })` | Fetch all entities of a type (minimal fields) | You want a quick inventory — "show me all competitors" |
 | `list_entities({ entityType })` | Fetch entities with full data (paginated) | You need actual content — "get full persona details" |
 | `get_entity({ oId })` | Deep dive on one specific entity | You found something notable and need the complete picture |
 | `search_knowledge_base({ query })` | Semantic search across library + resources | You have a concept — "how do we position against price objections?" |
@@ -47,10 +47,10 @@
 
 | What you need | Tool call | When to use |
 |---------------|-----------|-------------|
-| All competitors | `list_all_entities({ entityType: "competitor" })` | Quick inventory for breakdown charts |
+| All competitors | `list_entities({ entityType: "competitor" })` | Quick inventory for breakdown charts |
 | Competitor details | `get_entity({ oId })` | Deep dive when a competitor dominates losses |
-| All segments | `list_all_entities({ entityType: "segment" })` | Segment breakdown analysis |
-| All personas | `list_all_entities({ entityType: "persona" })` | Persona win rate analysis |
+| All segments | `list_entities({ entityType: "segment" })` | Segment breakdown analysis |
+| All personas | `list_entities({ entityType: "persona" })` | Persona win rate analysis |
 | Proof points | `list_entities({ entityType: "proof_point" })` | Evidence for "what's working" section |
 | All Motions | `list_motions()` | Inventory of Motions for Motion-level win rate analysis |
 | Motion ICP cells | `list_motion_icps({ motionOId })` | Cell-level breakdown (persona × segment) |

--- a/skills/workflow/references/workflow-file-format.md
+++ b/skills/workflow/references/workflow-file-format.md
@@ -113,7 +113,7 @@ Any MCP tool from the Octave server can be used in a workflow step:
 |-------|-------|
 | Research | `find_company`, `find_person`, `find_similar_companies`, `find_similar_people`, `enrich_company`, `enrich_person` |
 | Qualify | `qualify_company`, `qualify_person` |
-| Library | `list_all_entities`, `list_entities`, `get_entity`, `list_motions`, `list_motion_playbooks`, `get_motion_playbook`, `list_motion_icps`, `find_motion_icp`, `search_knowledge_base` |
+| Library | `list_entities`, `get_entity`, `list_motions`, `list_motion_playbooks`, `get_motion_playbook`, `list_motion_icps`, `find_motion_icp`, `search_knowledge_base` |
 | Conversation data | `list_events`, `list_findings`, `get_event_detail` |
 | Generate | `generate_email`, `generate_content`, `generate_call_prep` |
 | Agents | `run_email_agent`, `run_content_agent`, `run_call_prep_agent`, `run_enrich_person_agent`, `run_enrich_company_agent`, `run_qualify_person_agent`, `run_qualify_company_agent` |

--- a/skills/workspace/SKILL.md
+++ b/skills/workspace/SKILL.md
@@ -9,7 +9,7 @@ Show which Octave MCP server is connected.
 
 ## Instructions
 
-1. **Find the Octave MCP server** by looking at your available tools for ones like `verify_connection`, `get_entity`, `list_all_entities`.
+1. **Find the Octave MCP server** by looking at your available tools for ones like `verify_connection`, `get_entity`, `list_entities`.
 
 2. **Call `verify_connection`** to confirm the API key is valid and to fetch the authoritative workspace/organization names. This is the canonical probe.
 

--- a/workflows/content-sprint.workflow.md
+++ b/workflows/content-sprint.workflow.md
@@ -41,7 +41,7 @@ description: Find personas, use cases, and proof points for the theme. Layer in 
 
 Ensure content consistency.
 
-tool: list_all_entities
+tool: list_entities
 params:
   entityType: "brand_voice"
 save_as: brand_voices

--- a/workflows/full-outbound-pipeline.workflow.md
+++ b/workflows/full-outbound-pipeline.workflow.md
@@ -89,7 +89,7 @@ params:
 save_as: contacts
 description: Find people at the company matching the target persona titles and seniority level.
 
-Resolve {{persona_titles}} first: if a persona was specified (or auto-detected from the library), fetch its common job titles via `list_all_entities({ entityType: "persona" })` + `get_entity` and use those. Otherwise, search for senior decision-maker titles.
+Resolve {{persona_titles}} first: if a persona was specified (or auto-detected from the library), fetch its common job titles via `list_entities({ entityType: "persona" })` + `get_entity` and use those. Otherwise, search for senior decision-maker titles.
 
 Present the contact list with names, titles, and LinkedIn profiles.
 

--- a/workflows/persona-targeted-outreach.workflow.md
+++ b/workflows/persona-targeted-outreach.workflow.md
@@ -43,7 +43,7 @@ params:
 save_as: persona
 description: Fetch the full persona definition from your library including common job titles, pain points, key objectives, and qualification criteria.
 
-If the user provided a persona name rather than an oId, first use `list_all_entities({ entityType: "persona" })` to find the matching persona and save its oId as persona_oId.
+If the user provided a persona name rather than an oId, first use `list_entities({ entityType: "persona" })` to find the matching persona and save its oId as persona_oId.
 
 Present the persona overview to confirm this is the right target.
 

--- a/workflows/positioning-exercise.workflow.md
+++ b/workflows/positioning-exercise.workflow.md
@@ -24,25 +24,25 @@ End-to-end workflow for building a complete Messaging & Positioning system — f
 
 Check that all required entity types exist before generating frameworks.
 
-tool: list_all_entities
+tool: list_entities
 params:
   entityType: "product"
 save_as: products
 description: Verify products exist — the positioning system needs at least one product. If multiple products exist and no product_name input was given, ask the user which one to position; save the chosen product's oId as selected_product_oId.
 
-tool: list_all_entities
+tool: list_entities
 params:
   entityType: "persona"
 save_as: personas
 description: Check personas — needed for Message Framework, Persona Messaging, Homepage Messaging.
 
-tool: list_all_entities
+tool: list_entities
 params:
   entityType: "use_case"
 save_as: use_cases
 description: Check use cases — needed for Use Case Canvas and Lifecycle.
 
-tool: list_all_entities
+tool: list_entities
 params:
   entityType: "competitor"
 save_as: competitors
@@ -85,18 +85,21 @@ description: Full product details — category, capabilities, features, position
 tool: list_entities
 params:
   entityType: "persona"
+  includeDetails: true
 save_as: persona_details
 description: Full persona data — roles, pain points, priorities, workflows.
 
 tool: list_entities
 params:
   entityType: "segment"
+  includeDetails: true
 save_as: segment_details
 description: Full segment data — firmographics, criteria, sizing.
 
 tool: list_entities
 params:
   entityType: "use_case"
+  includeDetails: true
 save_as: use_case_details
 description: Full use case data — descriptions, workflows, outcomes.
 
@@ -122,6 +125,7 @@ description: List Motion Playbooks (Default + any Custom). Fetch each Custom Mot
 tool: list_entities
 params:
   entityType: "proof_point"
+  includeDetails: true
 save_as: proof_points
 description: Proof points for evidence in Strategy table and Anchors.
 
@@ -134,9 +138,10 @@ params:
 save_as: positive_findings
 description: What resonates in real conversations — grounds Anchors and Awareness Funnel.
 
-tool: list_all_entities
+tool: list_entities
 params:
   entityType: "brand_voice"
+  includeDetails: true
 save_as: brand_voices
 description: Brand voice for Homepage Messaging tone consistency.
 

--- a/workflows/quarterly-gtm-review.workflow.md
+++ b/workflows/quarterly-gtm-review.workflow.md
@@ -83,7 +83,7 @@ description: Identify messaging and value props that are landing well.
 
 Pull current library definitions for comparison.
 
-tool: list_all_entities
+tool: list_entities
 params:
   entityType: "segment"
 save_as: current_segments
@@ -93,7 +93,7 @@ description: Get current ICP segment definitions to compare against deal data.
 
 Pull persona definitions.
 
-tool: list_all_entities
+tool: list_entities
 params:
   entityType: "persona"
 save_as: current_personas
@@ -103,7 +103,7 @@ description: Get current persona definitions for effectiveness analysis.
 
 Check competitive activity.
 
-tool: list_all_entities
+tool: list_entities
 params:
   entityType: "competitor"
 save_as: competitors


### PR DESCRIPTION
## What

`list_all_entities` is merged into `list_entities`. `list_entities` now returns **slim rows** (oId, name, description) by default, and takes:

- `includeDetails: true` — the full entity body for each row
- `search` — filter by name/description
- `all: true` — return every match in one response
- `limit` / `offset` — pagination

## Why

Token optimization and a simpler surface. One list tool that's cheap by default (slim rows for browsing, discovery, and oId lookup) and opts into full detail only when a step actually needs it.

## Changes

- Repoint every `list_all_entities` reference to `list_entities` — the old tool was already slim, so behavior matches
- `positioning-exercise` workflow: mark the detail-fetch steps with `includeDetails: true` (they consume full entity bodies)
- Document the slim-first fetch convention in `skills/shared/entity-model.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
