### PR TITLE
Add Claude Tag support: octave-mcp plugin + setup guide

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,6 +19,17 @@
         "url": "https://octavehq.com"
       },
       "homepage": "https://octavehq.com"
+    },
+    {
+      "name": "octave-mcp",
+      "source": "./plugins/octave-mcp",
+      "description": "Credential-less declaration of the Octave MCP server — pair with an externally managed credential (e.g. a Claude Tag access bundle's Bearer API key)",
+      "version": "1.0.0",
+      "author": {
+        "name": "Octave",
+        "url": "https://octavehq.com"
+      },
+      "homepage": "https://octavehq.com"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ This repo is the source of truth. On every push to `main`, the same skills are a
 
 Install from the matching repo (see its README). Don't edit those repos directly — they're generated and overwritten. File issues and PRs here.
 
+### Claude Tag (Claude in Slack)
+
+[Claude Tag](https://claude.com/product/tag) lets a whole Slack workspace @-mention Claude in channels. It connects to Octave through an admin-provisioned **access bundle** rather than per-user OAuth, so setup differs from Claude Code:
+
+1. **Create an Octave API key** in Octave under **Settings → API Keys**. Claude Tag credentials are shared by everyone in the bundle's scope, so we recommend a **read-only** key (create one directly, or use the row menu → "Make read-only") unless you want channel members writing to your Library.
+2. **Add the credential**: in [claude.ai admin settings](https://claude.ai/admin-settings/claude-tag), open your access bundle → **Credentials → Connect another tool**. Choose credential type **Bearer**, name it "Octave MCP", set **Allowed websites** to `mcp.octavehq.com`, and paste the API key as the token. (The Octave MCP server accepts API keys via `Authorization: Bearer` or an `x-api-key` header.)
+3. **Attach the plugins**: in the bundle's **Plugins** tab, add this marketplace (`https://github.com/octavehq/lfgtm`) and enable both plugins:
+   - **`octave`** — the skills and agents in this repo
+   - **`octave-mcp`** — a credential-less `.mcp.json` that tells Claude the Octave MCP server exists at `https://mcp.octavehq.com/mcp`. No `ctx` parameter is needed: the API key identifies your workspace, and the bundle's credential is injected at the network layer.
+4. **Verify**: attach the bundle to a channel and send `@Claude verify your Octave connection`.
+
+The in-app guide (Octave → Settings → API Keys → Connect MCP → **Claude Tag**) walks through the same steps with copy buttons.
+
+> **Note:** `octave-mcp` is for externally injected credentials (Claude Tag). In Claude Code, keep using `claude mcp add` with your workspace URL as described below — the bare server declaration in `octave-mcp` has no credential and no workspace context on its own.
+
 ## Quick Start
 
 ### 1. Configure MCP Server

--- a/plugins/octave-mcp/.claude-plugin/plugin.json
+++ b/plugins/octave-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "octave-mcp",
+  "version": "1.0.0",
+  "description": "Declares the Octave MCP server (https://mcp.octavehq.com/mcp) without embedding credentials — for environments that inject auth externally, such as Claude Tag access bundles where an admin attaches an Octave API-key credential and this plugin tells Claude the server exists. Claude Code users should instead run `claude mcp add` with their workspace URL (see the lfgtm README).",
+  "author": {
+    "name": "Octave",
+    "url": "https://octavehq.com"
+  }
+}

--- a/plugins/octave-mcp/.mcp.json
+++ b/plugins/octave-mcp/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "octave": {
+      "type": "http",
+      "url": "https://mcp.octavehq.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds support for using Octave with [Claude Tag](https://claude.com/product/tag) (Claude in Slack), which connects to tools through admin-provisioned access bundles rather than per-user OAuth.

- **New `octave-mcp` plugin** — a credential-less `.mcp.json` declaring the Octave MCP server at `https://mcp.octavehq.com/mcp`. Claude Tag's credential proxy injects the auth (a Bearer API key configured on the access bundle) at the network layer, and the API key identifies the workspace, so the plugin needs no `ctx` parameter and stores no secrets.
- **README: "Claude Tag (Claude in Slack)" section** — admin setup guide: create a read-only Octave API key, add a Bearer credential to the access bundle (allowed website `mcp.octavehq.com`), attach the `octave` + `octave-mcp` plugins from this marketplace, verify from a channel.

The `octave` plugin itself is unchanged — Claude Code users keep using `claude mcp add` with OAuth as before; the README note makes that explicit.

## Test plan

- `marketplace.json` and both new plugin files are valid JSON
- Verified the new plugin dir follows the Claude plugin layout (`.claude-plugin/plugin.json` + root `.mcp.json`)
- End-to-end Claude Tag verification happens against a live access bundle once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)