### PR TITLE
Add GTM report digest skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "octave",
       "source": "./",
       "description": "Access Octave's GTM knowledge base for positioning, research, content generation, and sales enablement",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "author": {
         "name": "Octave",
         "url": "https://octavehq.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octave",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Octave GTM knowledge base integration for Claude Code, OpenAI Codex, and Cursor — provides bidirectional access to personas, Motions, messaging, and more. Give your AI grounded context for your GTM motions.",
   "author": {
     "name": "Octave",

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ See [**docs/org-instructions/**](docs/org-instructions/) for short and long reco
 | Skill | Description |
 |-------|-------------|
 | `/octave:insights` | Surface findings, trends, and patterns from calls and emails |
+| `/octave:digest` | Turn completed GTM reports into a branded magazine, slide deck, interactive microsite, one pager, executive brief, Markdown digest, or recurring published digest with selectable evidence depth |
 | `/octave:signals` | Morning intelligence briefing — deals, patterns, and signals demanding attention |
 | `/octave:win-loss-report` | Visual win/loss analysis report as self-contained HTML with charts — patterns, competitor cuts, and deal deep dives |
 | `/octave:icp-refine` | Refine ICP definitions using deal outcome analysis |

--- a/skills/deck/SKILL.md
+++ b/skills/deck/SKILL.md
@@ -615,6 +615,8 @@ Every slide is a fixed 1920×1080 canvas; the controller scales the whole stage.
 2. **`overflow: hidden` on every `.slide`** (from viewport-base.css) — anything that doesn't fit is clipped, so it must fit by design.
 3. **Content density limits per slide type** (tighten for *speaker-led*, allow the upper bound for *reading-first* — see Step 1 density choice):
 
+**Numeric interpretation rule:** Every displayed number must state its unit in the same visual block, with the reporting period and scope nearby. If categories overlap, say so. If evidence was deduplicated, name the deduplication unit. Reader-facing slides use plain units such as calls, companies, deals, or buyer quotes. Never expose internal evidence mechanics through labels such as “receipt set.”
+
 | Slide Type | Max Content |
 |-----------|------------|
 | Title | 1 heading + 1 subtitle (2-3 lines max) |

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: digest
+description: Turn one or more Octave GTM Explorer / Beats reports into a branded, shareable digest with selectable insight scope, evidence depth, and output format. Use when the user asks for a report digest, weekly or monthly insight recap, executive intelligence brief, magazine-style insight story, report deck, or a recurring published summary of Octave insights.
+---
+
+# /octave:digest - GTM Insight Digest
+
+Turn completed Octave reports into one coherent editorial asset. On an interactive first run, ask the user what to include, what to call the digest, how much evidence to hydrate, how it should render, whether to publish it, and whether to repeat the workflow. On a scheduled run, reuse the approved named configuration without asking the same questions again.
+
+## Principles
+
+Read before generating:
+
+- [Editorial rules](../shared/editorial-rules.md)
+- [Information principles](../shared/information-principles.md)
+- [Presentation principles](../shared/presentation-principles.md) for visual output
+- [Brand kit usage](../shared/brand-kit-usage.md) for branded output
+- [Evidence and links](references/evidence-and-links.md) when quotes, citations, companies, people, deals, or source links are requested
+- [Format routing](references/format-routing.md) after the user selects an output format
+
+## Workflow
+
+### 1. Discover the available reports
+
+1. Call `verify_connection`.
+2. Call `list_gtm_reports`. If there is one obvious group, use it. If several are plausible, ask which group.
+3. Call `get_latest_gtm_report` for the selected group.
+4. Show a compact inventory with report title, period, and one-sentence delta. Do not dump the report prose.
+
+### Interactive and recurring modes
+
+Determine the run mode before intake:
+
+- **Interactive setup or ad hoc run:** explicitly ask the scope, evidence depth, output format, hosting, URL behavior, and scheduling questions below. Do not silently choose for the user unless they already answered or said to use your judgment.
+- **Scheduled run with a saved digest specification:** load it by digest name or slug and reuse the saved selection rule, evidence depth, format, audience, brand, hosting, timezone, URL behavior, and delivery destination. Do not ask the setup questions again.
+- **Scheduled run with missing or invalid configuration:** pause only for the missing decision. Save the answer back to the digest specification for future runs.
+
+Treat an explicit instruction in the current request as an answer. Do not ask the user to repeat information they already supplied.
+
+### 2. Choose insight scope
+
+For an interactive run, ask:
+
+> Which insights should this digest include?
+>
+> 1. All reports in this period
+> 2. A subset I choose
+> 3. Pick the strongest connected story for me
+
+For a subset, let the user select by displayed report title. For an editorial pick, choose reports that form one non-redundant narrative and briefly state the selection logic.
+
+Fetch every selected report with `get_report_run` and set `includeEvidence: { perSectionLimit: 3 }`. Use this evidence preview for every section so the initial digest has inspectable support without requiring full hydration. Never build a multi-report digest from summary-only data.
+
+When the user selects all reports, include every completed report returned for the period. Do not infer missing reports from the group's configured report count. If the configured and completed counts differ, state the completed count in the artifact and note the discrepancy during delivery.
+
+### 3. Name the digest
+
+For an interactive first run, ask:
+
+> What should this digest be called?
+
+Offer a concise default derived from the report group, audience, or theme, such as `Weekly Competitive Intelligence` or `Executive Buyer Signals`. Let the user accept or replace it.
+
+Treat the name as the identity of this digest configuration, not as a global workspace setting. Derive a stable slug from the approved name and use it to scope saved configuration, recurring schedules, hosted assets, and update-in-place URLs. A workspace may have multiple named digests with different report scope, format, audience, privacy, and cadence.
+
+If the derived slug already belongs to a different digest specification, ask whether to update that digest or choose another name. Never silently overwrite another digest.
+
+### 4. Choose evidence depth
+
+The default is the evidence preview returned by `get_report_run({ includeEvidence: { perSectionLimit: 3 } })`.
+
+For an interactive run, ask whether the user wants to go beyond that preview:
+
+> The digest will include a short evidence preview by default. Do you want detailed evidence too?
+>
+> 1. Preview only: evidence counts and a few supporting examples
+> 2. Selected details: verified quotes and source context for the most important claims
+> 3. Full receipts: quotes, companies, people, deal context, and source links where available
+
+Explain that options 2–3 call `get_report_section_evidence` and may require additional event hydration, so they take longer and consume more tokens. Never fabricate precision to compensate for missing evidence.
+
+Follow [evidence-and-links.md](references/evidence-and-links.md). Keep private deal or person details out of externally shared output unless the user explicitly confirms the audience and inclusion.
+
+### 5. Choose content density
+
+For an interactive run, ask:
+
+> How should this digest read?
+>
+> 1. Executive: compressed conclusions, key evidence, and actions
+> 2. Detailed: more of the reports' reasoning, examples, caveats, and section-level prose
+
+Content density is separate from evidence depth. Detailed mode may use report prose without exposing named people, companies, deals, or verbatim quotes. Evidence privacy choices still apply.
+
+In detailed mode:
+
+- Start from the full `get_report_run` summary, comparison, and section details
+- Preserve meaningful reasoning and concrete examples that explain why each conclusion holds
+- Edit for coherence and remove repetition across overlapping reports
+- Attribute each analytical section to its source report
+- Add pages or slides instead of shrinking type, overfilling layouts, or turning prose into tiny cards
+- Do not paste report text wholesale; shape it into a readable combined narrative
+
+### 6. Choose the output
+
+For an interactive run, ask:
+
+> What should I generate?
+>
+> 1. Magazine style
+> 2. Slide deck
+> 3. Interactive microsite
+> 4. One pager
+> 5. Executive brief
+> 6. Markdown digest
+
+Supported formats, in display order: magazine style, slide deck, interactive microsite, one pager, executive brief, or Markdown.
+
+Use [format-routing.md](references/format-routing.md). Reuse the selected reports, narrative, evidence packet, and workspace brand kit across formats. If the user asks for multiple formats, establish one approved content brief before rendering any of them.
+
+If the user requests both Executive and Detailed variants, treat them as adaptations of one shared source packet:
+
+- Keep the reporting window, report scope, claim provenance, evidence counts, privacy decisions, and core conclusion consistent
+- Executive versions compress to decisions, major evidence, and actions
+- Detailed versions preserve report-level reasoning, caveats, concrete examples, and additional source context
+- Do not independently research each variant or allow their factual claims to drift
+
+Magazine length is narrative-driven. Never force a fixed spread count.
+
+### 7. Build the content brief
+
+Present for approval:
+
+- Audience and decision the digest should support
+- Digest name and stable slug
+- Included reports and period
+- Display date range. Show a timezone only when an exact timestamp boundary materially affects which evidence is included.
+- Main conclusion
+- Narrative arc
+- Section or slide outline
+- Content density
+- Evidence mode and privacy assumptions
+- Planned links back to Octave
+- Whether to include a source appendix and “Chat with this insight” prompt
+
+Wait for approval before generating visual output.
+
+### 8. Generate and review
+
+1. Load or capture the workspace brand kit.
+2. Generate through the selected format skill or reference. Use the digest-native magazine specification in [format-routing.md](references/format-routing.md) for editorial swipe magazines; do not route magazines through `/octave:deck`.
+3. Include source notes only where they help verification.
+4. Run the mandatory review protocol used by the selected format.
+5. For internal output, include Octave report links as described in [evidence-and-links.md](references/evidence-and-links.md).
+6. For magazine output, run the multi-aspect responsive review gate in [format-routing.md](references/format-routing.md); a single desktop screenshot is insufficient.
+7. For magazine output, run the nested-surface contrast check in [format-routing.md](references/format-routing.md). Light panels inside dark spreads and dark panels inside light spreads must explicitly reset foreground colors. Text that is visible only when selected is a hard failure.
+8. Every displayed number must tell the reader what it counts. Put the unit next to the value, state the reporting period and scope nearby, and explain deduplication or overlap when categories are not mutually exclusive. Translate internal evidence mechanics into reader language: use “calls,” “companies,” “deals,” or “buyer quotes,” never an unexplained label such as “receipt set.”
+9. When defensible totals are available, put a compact sample-size line on the title or opening spread (for example: calls, companies, evidence excerpts, and completed reports). Keep the reporting window separately visible so readers can judge coverage before interpreting the story.
+
+For internal visual output, offer a compact source appendix after the main narrative and before the closing. The appendix may include:
+
+- Included report titles, reporting windows, and links back to the full reports in Octave
+- A brief scope or evidence note
+- A copyable **Chat with this insight** starter prompt that tells the reader to use the Octave MCP, identifies the reports by stable title or identifier, and asks a useful follow-up question
+
+Keep the starter prompt portable: do not assume a specific AI client or expose private evidence. Ask the MCP to fetch the current report rather than embedding the entire report in the prompt. When a stable report identifier is available, include it alongside the human-readable title.
+
+For every output, state the reporting window prominently. Do not display a timezone for ordinary day- or week-based windows; include one only when an exact timestamp boundary materially affects scope. When the digest combines multiple reports or insight threads, visual formats must include:
+
+- A cover or opening view with the digest title, reporting window, and scope
+- A contents or agenda view naming each included report or insight thread
+- Clear section dividers or navigation that preserve report provenance while supporting one combined narrative
+
+Do not make readers infer which period or source report a claim belongs to.
+
+### 9. Offer hosting
+
+After the artifact passes review on an interactive run, ask:
+
+> Host this with Octave Asset Manager?
+>
+> 1. Workspace access
+> 2. Public link
+> 3. Only me
+> 4. Not now
+
+If yes, also ask:
+
+> What kind of URL should this use?
+>
+> 1. Stable or vanity URL that updates in place
+> 2. New versioned URL for every digest
+
+Recommend a stable URL for recurring digests and a versioned URL for immutable reports or campaign-specific deliverables. If the user chooses a stable URL, ask for the preferred readable slug or offer one derived from the digest name.
+
+Then hand off to `/octave:asset-manager`. Pass the chosen access level and URL behavior with the approved artifact. That skill owns identifier choice, slug availability, privacy confirmation, token handling, upload or update-in-place behavior, and final links. Do not duplicate its publish workflow here.
+
+### 10. Offer scheduling
+
+After delivery on an interactive run, ask:
+
+> Run this digest on a schedule?
+>
+> 1. Weekly
+> 2. Monthly
+> 3. Custom cadence
+> 4. No
+
+Clarify what should recur:
+
+- **Report schedule:** Octave produces the underlying GTM reports.
+- **Digest schedule:** the approved selection, evidence mode, format, hosting privacy, and audience are applied to each new period.
+
+Use the runtime's recurring-task or monitoring capability when available. Save a named digest specification containing the digest name and slug, report group, selection rule, content density, evidence depth, format, audience, brand, hosting privacy, URL behavior and stable slug when applicable, timezone, and delivery destination. Key saved state by digest identity rather than a single global digest setting. Instruct the recurring run to load this specification and skip interactive intake unless a required value is missing or the report source becomes invalid. If no scheduler is available, say so plainly and provide the complete schedule specification for later activation. Never claim a schedule was created without a confirmed scheduler result.
+
+## Defaults
+
+When the user says “use your judgment”:
+
+- Scope: strongest connected story, not every report
+- Name: offer a concise derived name and ask the user to accept or replace it
+- Content density: executive
+- Evidence: the `get_report_run` evidence preview, with no private deal details
+- Format: executive brief for internal reading
+- Links: include report links for internal readers
+- Hosting: ask after review, including stable/vanity versus versioned URL
+- Scheduling: ask after delivery
+
+## Error handling
+
+**No completed reports:** offer `/octave:insights` for an event-and-finding digest or ask the user to widen the report group or period.
+
+**Selected report has no sections:** use its comparison and summary, label the evidence as limited, and do not inflate the output.
+
+**Evidence cannot be hydrated:** generate from report sections and counts, state that quotes and entity-level citations were unavailable, and offer to continue without them.
+
+**External audience with private evidence selected:** pause and confirm exactly which companies, people, quotes, and deal details may be disclosed.
+
+## Related skills
+
+- `/octave:insights` for ad hoc findings that are not based on completed reports
+- `/octave:deck` for presentation rendering
+- `/octave:microsite` for interactive web output
+- `/octave:one-pager` for a compact leave-behind
+- `/octave:asset-manager` for hosting and sharing

--- a/skills/digest/references/evidence-and-links.md
+++ b/skills/digest/references/evidence-and-links.md
@@ -1,0 +1,82 @@
+# Evidence hydration and Octave links
+
+Use this reference when the digest includes quotes, companies, people, deals, citations, or links back to Octave.
+
+## Evidence modes
+
+### Evidence preview
+
+Call `get_report_run` with `includeEvidence: { perSectionLimit: 3 }`. Use its per-section preview and evidence counts as the default for every digest. Keep claims at the level supported by the report. Do not turn a count of linked findings into a count of unique companies or deals.
+
+### Selected quotes
+
+For each important section:
+
+1. Call `get_report_section_evidence` for the exact report section.
+2. Hydrate promising events with `get_event_detail` when the returned preview lacks required context.
+3. Use `search_call_transcripts` when verbatim, speaker-attributed language is required.
+4. Keep only quotes whose wording and attribution can be verified.
+
+If `get_report_section_evidence` is unavailable, search `list_findings` using the section topic, report window, and relevant filters. State that this fallback may not reproduce the report section's exact evidence set because semantic search is not the same as traversing the section-to-finding links.
+
+## Evidence-worthiness gate
+
+Evidence is optional, even when it is available. Include an item only when it:
+
+- Directly supports the spread's main claim
+- Adds specificity, tension, language, or context that the report summary does not already provide
+- Is understandable without reconstructing the full conversation
+- Has enough source context to avoid a misleading interpretation
+- Is appropriate for the confirmed audience and privacy level
+
+Prefer one strong receipt over several weak snippets. Cut generic labels, fragments, routine feature questions, seller monologues, repeated examples from the same event, and quotes chosen only because they sound colorful. Do not use a quote as decoration.
+
+For each candidate, ask:
+
+1. What claim does this prove?
+2. What does the reader learn from it that they did not already know?
+3. Would removing it weaken the argument?
+
+If those answers are unclear, omit it. Paraphrase when the idea matters but the verbatim language is noisy. Label paraphrases as conversation summaries, never as quotes.
+
+### Full receipts
+
+Hydrate:
+
+- Verbatim quote or exact quoted phrase
+- Speaker and title when confirmed
+- Company
+- Event date and type
+- Deal name, stage, amount, and outcome when available and relevant
+- Recording or event link when the tool returns one
+
+Deduplicate companies and events before reporting frequencies. Separate the number of findings, calls, companies, and deals. They are not interchangeable.
+
+## Links back to Octave
+
+Call `verify_connection` to resolve `organizationSlug` and `workspaceOId`.
+
+For each report run, build:
+
+```text
+https://app.octavehq.com/o/{organizationSlug}/{workspaceOId}/insights?view=beats&reportRun={reportRunOId}
+```
+
+Use links only for internal readers who can access the workspace. Label them clearly, for example `View the full report in Octave`.
+
+For public or customer-facing assets:
+
+- Omit workspace links by default because recipients cannot open them.
+- Include them only when the user confirms the audience has Octave access.
+- Never expose raw oIds as reader-facing copy.
+
+## Privacy gate
+
+Before rendering named companies, people, quotes, or deal information, establish whether the artifact is:
+
+- Internal
+- Workspace-shared
+- Restricted external
+- Public
+
+Internal does not mean unrestricted. Include only details that serve the argument. For external or public output, require explicit confirmation for private CRM and conversation details.

--- a/skills/digest/references/format-routing.md
+++ b/skills/digest/references/format-routing.md
@@ -1,0 +1,137 @@
+# Digest format routing
+
+Route the approved digest brief into the appropriate renderer.
+
+## Executive brief
+
+Create a reading-first HTML document using the shared HTML-document principles. Use a strong executive summary, 3–6 analytical sections, evidence notes, recommendations, and source links.
+
+## Editorial swipe magazine
+
+This is a digest-native format. Do not invoke `/octave:deck` or reuse its slide DOM, fixed-stage scaffold, or slide templates.
+
+Create a single horizontal-swipe HTML file:
+
+- Each spread is `100vw × 100vh`
+- Horizontal scroll snap, no vertical page scrolling
+- Full-bleed, edge-to-edge editorial compositions
+- Narrative-driven spread count
+- Start with a cover showing the reporting window. Omit the timezone for ordinary day- or week-based windows; show it only when an exact timestamp boundary materially affects scope.
+- For multi-report digests, follow the cover with a contents spread naming the included reports or insight threads
+- Cover and back cover may be sparse; analytical spreads should pair a dominant claim with inspectable evidence
+- Add bottom navigation, ArrowLeft/ArrowRight, Home/End, touch swipe, reduced motion, and one-spread-per-page print styles
+- Do not use experimental canvas or shader effects
+
+### Art direction contract
+
+Treat the brand kit as source material for an editorial system, not as a logo-and-color skin. Reuse its actual typefaces, palette, marks, image treatment, and signature moves.
+
+- Give every spread a deliberate composition. Use split color fields, asymmetric columns, viewport-filling grids, 2×2 quadrants, oversized typography, edge-bound rules, full-bleed imagery, and annotated diagrams.
+- Do not place a centered stack of padded cards on a decorative background. When cards are semantically necessary, integrate them into a full-width grid or editorial evidence table.
+- Make important verified statistics visual anchors. On desktop, the primary statistic should usually render at least 100px tall; use responsive constraints so it still fits shorter viewports.
+- Label every oversized numeral by meaning. Structural numbers must visibly say `REPORT`, `SECTION`, `ISSUE`, or `PAGE` in the same composition; never let a chapter number resemble an evidence count or performance metric.
+- Label every evidence count with a reader-understandable unit such as calls, companies, deals, or buyer quotes. State the period and scope nearby, and disclose overlap when one source can support multiple categories. Do not use internal labels such as “receipt set.”
+- When defensible totals are available, include a compact sample-size line on the title or opening spread: calls, companies, evidence excerpts, and completed reports. Keep the reporting window separately visible.
+- Use high contrast rhythm. Make the cover and closing dark, add at least one dark interior spread, and use dark or saturated fields for roughly one-third of a longer magazine.
+- Change the dominant surface, composition, or color field between consecutive spreads. Avoid a sequence of white pages with interchangeable content blocks.
+- Give analytical spreads at least two information layers, such as claim plus evidence, prose plus data, comparison plus annotation, or quote plus source context.
+- Treat evidence as editorial material, not filler. Use only items that pass the evidence-worthiness gate in [evidence-and-links.md](evidence-and-links.md), and design their source context into the composition.
+- Use the full viewport. Intentional negative space should focus attention; it must not make evidence spreads feel unfinished or underfilled.
+- Favor a few bold, brand-specific moves over many generic effects. Decoration must improve hierarchy, comprehension, or pacing.
+
+The magazine is not a reskinned deck:
+
+- Write magazine-specific markup and layouts instead of reusing slide DOM
+- Use editorial pacing: opener, contents, section openers, reported features, evidence sidebars, pull quotes, annotated comparisons, and a closing
+- Allow more prose and evidence than the deck while keeping each spread legible without vertical scrolling
+- Use side-by-side compositions where one field carries the main argument and the other carries evidence, context, or source notes
+- Preserve meaningful negative space, but do not leave analytical spreads underfilled
+- Vary density intentionally: sparse cover and section openers, medium-density reported features, and dense but legible evidence or comparison spreads
+
+### Detailed magazine mode
+
+When content density is `detailed`:
+
+- Give each selected report enough room to preserve its section-level reasoning; add spreads based on narrative need
+- Use reported features with a claim, 2–4 short paragraphs, and a separate evidence or context field
+- Keep body copy comfortably readable, generally 18–24px on a 1080px-tall desktop viewport
+- Split long sections across spreads by idea; never reduce body type to fit
+- Carry concrete examples and caveats forward when they change the interpretation
+- Remove repeated setup across reports and use cross-references to connect overlapping themes
+- Retain cover, contents, section openers, evidence treatments, synthesis, and closing so the result still reads like a magazine
+
+### Motion
+
+- Use native scroll snap for direct manipulation and interruptibility
+- For programmatic page changes, target roughly 280–360ms with `cubic-bezier(0.2, 0, 0, 1)`; avoid slow cinematic transitions
+- Stagger optional content entrances by about 80–100ms and keep them under 400ms
+- Respect `prefers-reduced-motion` by removing smooth scrolling and entrance motion
+- Controls need at least a 40×40px hit area
+
+### Responsive review gate
+
+Before delivery, inspect the cover, contents, densest editorial spread, and closing at:
+
+- 16:9 desktop
+- 16:10 desktop
+- Ultrawide, at least 21:9
+- A narrower tablet or mobile landscape viewport
+
+Use width-and-height-constrained type sizing such as `min(vw, vh)` or container queries. Pure `vw` display type is not acceptable because it can collide vertically on ultrawide screens. Check for overlap, clipping, unreadably small type, and unexpected vertical scrolling at every viewport.
+
+Also inspect every composition where a light panel is nested inside a dark or saturated spread, and every dark panel nested inside a light spread. Container background changes must explicitly reset the foreground color instead of inheriting it from the parent spread.
+
+Run a computed-style contrast check on rendered text elements before delivery:
+
+- Resolve each text element's effective foreground color and the painted background of its nearest opaque ancestor
+- Flag white or near-white text on white or near-white surfaces, and dark text on dark surfaces
+- Treat text that becomes readable only when selected or highlighted as a hard failure
+- Re-render and visually confirm every flagged spread after fixing it
+
+## Presentation deck
+
+Hand off to `/octave:deck` with the approved narrative, evidence packet, audience, reporting window, source timezone, and brand kit. The source timezone controls evidence selection but should not be displayed unless an exact timestamp boundary materially affects scope. Do not repeat its intake. Use a fixed 1920×1080 stage and its mandatory review loop. For multi-report digests, require a dated title slide followed by an agenda that names the included reports or insight threads.
+
+For `detailed` density, select the deck skill's reading-first mode. Preserve report reasoning by splitting each major section into its own slide or tightly related two-section comparison. Do not paste paragraphs into a speaker-led layout or shrink body copy below the deck's readable limits.
+
+## Source appendix
+
+For internal deck and magazine output, offer a compact appendix after the recommendations and before the closing:
+
+- Name and link every included Octave report
+- Show the reporting window. Show a timezone only when an exact timestamp boundary materially affects scope.
+- State the selected evidence depth and any privacy limitation
+- Include a copyable **Chat with this insight** prompt
+
+The prompt should direct the reader to use the Octave MCP and fetch the named reports by stable identifier when available. Give it a specific analytical starting point, but make clear the reader can replace that question. Keep the appendix visually secondary to the narrative; it should not become a dense evidence dump.
+
+## Interactive microsite
+
+Hand off to `/octave:microsite`. Favor a scannable landing-page narrative, anchored navigation, interactive evidence details, and a clear final action. Do not turn it into a dashboard unless the content requires data exploration.
+
+## One-page summary
+
+Hand off to `/octave:one-pager`. Compress to the conclusion, 3–5 key findings, the most credible evidence, and specific recommendations.
+
+## Markdown digest
+
+Produce portable Markdown with:
+
+- Title and reporting window
+- Executive summary
+- Findings ordered by impact
+- Evidence and source links
+- Recommendations
+- Method and privacy note when evidence was hydrated
+
+## Multiple formats
+
+Approve one content brief first. Render the densest reading format before adapting to lower-density presentation formats, so evidence is not lost during synthesis.
+
+When producing an Executive and Detailed pair:
+
+- Build the Detailed narrative first from the shared report and evidence packet
+- Derive the Executive narrative by compression, not by running a separate synthesis
+- Preserve the same report inventory, reporting window, source links, and central recommendation
+- Let page or slide counts differ; visual parity does not require structural parity
+- Use the same appendix source inventory in both variants, with shorter methodology copy in the Executive version


### PR DESCRIPTION
## What changed

- adds the public `/octave:digest` workflow for completed GTM reports
- supports named digest specifications, all/subset/editorial scope, Executive or Detailed density, and configurable evidence depth
- routes output to magazine style, slide deck, interactive microsite, one pager, executive brief, or Markdown
- adds recurring schedule, asset-manager hosting, stable URL, Octave source-link, and “Chat with this insight” guidance
- adds reader-facing numeric interpretation rules to the deck skill
- bumps the plugin and marketplace version from 2.3.1 to 2.3.2

## Why

Teams need a reusable way to turn one or more completed Beats reports into coherent, branded assets without leaking internal evidence mechanics or losing report provenance and period-over-period changes.

## Validation

- `quick_validate.py skills/digest`
- `./scripts/build-codex.sh`
- `./scripts/build-cursor.sh`
- `git diff --check`
