### PR TITLE
digest: dispatch-voice editorial rules + wire the mandatory review gate (2.3.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "octave",
       "source": "./",
       "description": "Access Octave's GTM knowledge base for positioning, research, content generation, and sales enablement",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "author": {
         "name": "Octave",
         "url": "https://octavehq.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octave",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Octave GTM knowledge base integration for Claude Code, OpenAI Codex, and Cursor — provides bidirectional access to personas, Motions, messaging, and more. Give your AI grounded context for your GTM motions.",
   "author": {
     "name": "Octave",

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -18,6 +18,10 @@ Read before generating:
 - [Evidence and links](references/evidence-and-links.md) when quotes, citations, companies, people, deals, or source links are requested
 - [Format routing](references/format-routing.md) after the user selects an output format
 
+The editorial rules apply to **titles and headings**, not just body copy. Every chapter, section, and spread title must state its finding as an intelligible sentence, or, if it is a short label, be clearly decipherable on its own. A vague evocative fragment that could sit on any report ("The Pressure," "The New Owner," "The Wall") does not pass: lead with the claim it stands in for. State the finding **plainly**. A dramatic reversal or clever turn ("we won X and inherited Y," "we won the argument and lost the war") fails on the opposite end, reading as performative even when the underlying finding is real. The editorial review must audit titles the same way it audits prose.
+
+**Write like a dispatch, not an inside joke.** Frame every finding for a reader who was not on the calls and does not yet share the context. State plainly what happened, to whom, and why it matters before layering in the clever turn. An elliptical, knowing line that assumes shared context ("Buyers stopped asking why and started handing our own framing back to us," "the conversation moved") is a failure even when it is literally true: the reader has to reverse-engineer what it means. A real magazine sets the scene, then delivers the point. Prefer the sentence a smart colleague who missed the week would understand on first read over the one that sounds knowing to someone who was there.
+
 ## Workflow
 
 ### 1. Discover the available reports
@@ -77,7 +81,7 @@ For an interactive run, ask whether the user wants to go beyond that preview:
 > 2. Selected details: verified quotes and source context for the most important claims
 > 3. Full receipts: quotes, companies, people, deal context, and source links where available
 
-Explain that options 2–3 call `get_report_section_evidence` and may require additional event hydration, so they take longer and consume more tokens. Never fabricate precision to compensate for missing evidence.
+Explain that options 2 to 3 call `get_report_section_evidence` and may require additional event hydration, so they take longer and consume more tokens. Never fabricate precision to compensate for missing evidence.
 
 Follow [evidence-and-links.md](references/evidence-and-links.md). Keep private deal or person details out of externally shared output unless the user explicitly confirms the audience and inclusion.
 
@@ -147,15 +151,62 @@ Wait for approval before generating visual output.
 
 ### 8. Generate and review
 
-1. Load or capture the workspace brand kit.
+1. Load or capture the workspace brand kit **first**, and set the digest in **its** typefaces (read them from the kit's `tokens.css` / manifest), not a generic editorial pairing. Then make sure those brand fonts are actually loaded and, for any hosted or shared digest, self-contained (`@font-face` with base64 `src`, not a remote `@import`/CDN link) so the render never falls back to a system font. Using generic type when a kit exists, or leaving a font unloaded, is a defect. See the font rules in [format-routing.md](references/format-routing.md).
 2. Generate through the selected format skill or reference. Use the digest-native magazine specification in [format-routing.md](references/format-routing.md) for editorial swipe magazines; do not route magazines through `/octave:deck`.
 3. Include source notes only where they help verification.
-4. Run the mandatory review protocol used by the selected format.
-5. For internal output, include Octave report links as described in [evidence-and-links.md](references/evidence-and-links.md).
-6. For magazine output, run the multi-aspect responsive review gate in [format-routing.md](references/format-routing.md); a single desktop screenshot is insufficient.
-7. For magazine output, run the nested-surface contrast check in [format-routing.md](references/format-routing.md). Light panels inside dark spreads and dark panels inside light spreads must explicitly reset foreground colors. Text that is visible only when selected is a hard failure.
-8. Every displayed number must tell the reader what it counts. Put the unit next to the value, state the reporting period and scope nearby, and explain deduplication or overlap when categories are not mutually exclusive. Translate internal evidence mechanics into reader language: use “calls,” “companies,” “deals,” or “buyer quotes,” never an unexplained label such as “receipt set.”
-9. When defensible totals are available, put a compact sample-size line on the title or opening spread (for example: calls, companies, evidence excerpts, and completed reports). Keep the reporting window separately visible so readers can judge coverage before interpreting the story.
+4. For internal output, include Octave report links as described in [evidence-and-links.md](references/evidence-and-links.md).
+5. Every displayed number must tell the reader what it counts. Put the unit next to the value, state the reporting period and scope nearby, and explain deduplication or overlap when categories are not mutually exclusive. Translate internal evidence mechanics into reader language: use “calls,” “companies,” “deals,” or “buyer quotes,” never an unexplained label such as “receipt set.”
+6. When defensible totals are available, put a compact sample-size line on the title or opening spread (for example: calls, companies, evidence excerpts, and completed reports). Keep the reporting window separately visible so readers can judge coverage before interpreting the story.
+7. **Run the review gate. This is a mandatory step, not an option.** Do not open the artifact, present a delivery summary, or tell the user it is ready until the gate has run and produced a scorecard. Load the [review protocol](../shared/protocol.md); the wiring below is digest-specific.
+
+   **Which gate runs where.** For digest-native HTML this skill renders directly (editorial swipe magazine and executive brief), run the full gate here. For formats handed to another skill (`/octave:deck`, `/octave:microsite`, `/octave:one-pager`), that skill owns its own mandatory gate; do not duplicate it. For Markdown, run the editorial half only, since there is no visual layer. In every case the digest orchestrator stays responsible for groundedness: no claim, quote, number, or attribution ships that the source reports and evidence do not support.
+
+   **7a. Preflight (deterministic, always first).** Run the protocol preflight, then the digest lint, and fix every violation before spawning reviewers:
+
+   ```bash
+   bash <skill-dir>/scripts/lint.sh <path-to-output.html>
+   ```
+
+   **7b. Spawn the two dedicated reviewers in parallel** (both Task calls in one message):
+
+   **Editorial reviewer:**
+   ```
+   Task tool:
+     subagent_type: "octave-editorial-reviewer"
+     prompt: "Review the file at [FILE PATH].
+              Read and run the checklist in each of:
+              1. [skill-dir]/../shared/editorial-rules.md
+              2. [skill-dir]/../shared/information-principles.md
+              3. [skill-dir]/references/format-routing.md
+                 Audit titles AND body copy: every chapter, section, and
+                 spread title must state its finding as an intelligible
+                 sentence (not a vague evocative fragment, not a dramatic
+                 clever turn); body copy must frame each finding for a reader
+                 who was not on the calls, never dropping cryptic or elliptical
+                 lines that assume shared context.
+              Fix violations inline. Return scorecard."
+   ```
+
+   **Presentation reviewer:**
+   ```
+   Task tool:
+     subagent_type: "octave-presentation-reviewer"
+     prompt: "Review the file at [FILE PATH].
+              Read and run the checklist in each of:
+              1. [skill-dir]/../shared/presentation-principles.md
+              2. [skill-dir]/references/format-routing.md
+              For magazine output, run the full responsive review gate in that
+              file at 16:9, 16:10, ultrawide, and a narrow viewport: the
+              multi-aspect check, the nested-surface and per-spread contrast
+              check (including fixed navigation chrome that must stay visible
+              on both light and dark spreads), the title-states-its-finding
+              check, and the typefaces-actually-rendered check. A brand font
+              that is declared but not loaded and falls back to a system face
+              is a hard failure. A single desktop screenshot is insufficient.
+              Fix violations inline. Return scorecard."
+   ```
+
+   **7c. Loop and scorecard.** Follow the protocol's loop decision (max 3 cycles, re-run both reviewers each loop) and output the combined scorecard. Delivery cannot start without it.
 
 For internal visual output, offer a compact source appendix after the main narrative and before the closing. The appendix may include:
 

--- a/skills/digest/references/format-routing.md
+++ b/skills/digest/references/format-routing.md
@@ -4,7 +4,7 @@ Route the approved digest brief into the appropriate renderer.
 
 ## Executive brief
 
-Create a reading-first HTML document using the shared HTML-document principles. Use a strong executive summary, 3–6 analytical sections, evidence notes, recommendations, and source links.
+Create a reading-first HTML document using the shared HTML-document principles. Use a strong executive summary, 3 to 6 analytical sections, evidence notes, recommendations, and source links.
 
 ## Editorial swipe magazine
 
@@ -19,13 +19,15 @@ Create a single horizontal-swipe HTML file:
 - Start with a cover showing the reporting window. Omit the timezone for ordinary day- or week-based windows; show it only when an exact timestamp boundary materially affects scope.
 - For multi-report digests, follow the cover with a contents spread naming the included reports or insight threads
 - Cover and back cover may be sparse; analytical spreads should pair a dominant claim with inspectable evidence
-- Add bottom navigation, ArrowLeft/ArrowRight, Home/End, touch swipe, reduced motion, and one-spread-per-page print styles
+- Give every spread its own explicit background. Because spreads alternate between light and dark surfaces, a spread that inherits the page or `body` background instead of declaring its own will paint dark text on a dark field (or the reverse) and its content disappears. Set the surface and the foreground color together on each spread.
+- Add bottom navigation, ArrowLeft/ArrowRight, Home/End, touch swipe, reduced motion, and one-spread-per-page print styles. The navigation chrome is fixed over spreads of both polarities, so it must stay legible on light and dark surfaces alike: do not use white-on-transparent controls that vanish on a white spread. Use control and active-state colors that hold contrast against every surface in the magazine.
 - Do not use experimental canvas or shader effects
 
 ### Art direction contract
 
 Treat the brand kit as source material for an editorial system, not as a logo-and-color skin. Reuse its actual typefaces, palette, marks, image treatment, and signature moves.
 
+- **Set the digest in the brand kit's own typefaces, and actually load them.** Resolve the workspace brand kit first and read its real fonts from its `tokens.css` / manifest, then set the digest in those faces. Defaulting to a generic editorial pairing when a brand kit exists is the failure to avoid: the output must look like the brand, not a stock magazine template. Naming a font in `font-family` does not load it either, so the brand faces have to actually be delivered: because a digest is usually hosted or shared, **self-contain them** with `@font-face` and base64 `src` rather than a remote `@import`/CDN `<link>` that can be blocked in the hosted context. Only when no brand kit exists, choose a deliberate editorial pairing and load it the same way. A generic-instead-of-brand typeface, or a declared-but-unloaded one that falls back to a system font, is a defect, not a style choice.
 - Give every spread a deliberate composition. Use split color fields, asymmetric columns, viewport-filling grids, 2×2 quadrants, oversized typography, edge-bound rules, full-bleed imagery, and annotated diagrams.
 - Do not place a centered stack of padded cards on a decorative background. When cards are semantically necessary, integrate them into a full-width grid or editorial evidence table.
 - Make important verified statistics visual anchors. On desktop, the primary statistic should usually render at least 100px tall; use responsive constraints so it still fits shorter viewports.
@@ -47,14 +49,17 @@ The magazine is not a reskinned deck:
 - Use side-by-side compositions where one field carries the main argument and the other carries evidence, context, or source notes
 - Preserve meaningful negative space, but do not leave analytical spreads underfilled
 - Vary density intentionally: sparse cover and section openers, medium-density reported features, and dense but legible evidence or comparison spreads
+- Vary the prose cadence. Do not open every chapter with the same device (a before/after "last period, this period" turn) or lean on the same rhythm section after section (anaphora, rule-of-three, two-beat reversals). A uniform punchy cadence reads as machine-written even when the vocabulary is clean and the facts are real; a strong editor breaks the pattern deliberately.
+- Titles carry the finding. Every chapter, section, and spread title is held to the editorial standard: an intelligible sentence that states the actual finding, or, if a short label, one that is clearly decipherable on its own. A vague evocative fragment that could headline any report ("The Pressure," "The Wall") does not pass. Put the claim in the title itself, not only in a subhead beneath it.
+- Frame findings for a reader who was not there. Write like a dispatch that sets the scene before making its point, not like an inside note between people who shared the week. An elliptical, knowing line that is true but assumes context ("buyers stopped asking why," "the conversation moved") forces the reader to reconstruct the meaning; state plainly what happened and why it matters, then add the turn. Favor the sentence a smart colleague who missed the period would understand on first read.
 
 ### Detailed magazine mode
 
 When content density is `detailed`:
 
 - Give each selected report enough room to preserve its section-level reasoning; add spreads based on narrative need
-- Use reported features with a claim, 2–4 short paragraphs, and a separate evidence or context field
-- Keep body copy comfortably readable, generally 18–24px on a 1080px-tall desktop viewport
+- Use reported features with a claim, 2 to 4 short paragraphs, and a separate evidence or context field
+- Keep body copy comfortably readable, generally 18 to 24px on a 1080px-tall desktop viewport
 - Split long sections across spreads by idea; never reduce body type to fit
 - Carry concrete examples and caveats forward when they change the interpretation
 - Remove repeated setup across reports and use cross-references to connect overlapping themes
@@ -63,8 +68,8 @@ When content density is `detailed`:
 ### Motion
 
 - Use native scroll snap for direct manipulation and interruptibility
-- For programmatic page changes, target roughly 280–360ms with `cubic-bezier(0.2, 0, 0, 1)`; avoid slow cinematic transitions
-- Stagger optional content entrances by about 80–100ms and keep them under 400ms
+- For programmatic page changes, target roughly 280 to 360ms with `cubic-bezier(0.2, 0, 0, 1)`; avoid slow cinematic transitions
+- Stagger optional content entrances by about 80 to 100ms and keep them under 400ms
 - Respect `prefers-reduced-motion` by removing smooth scrolling and entrance motion
 - Controls need at least a 40×40px hit area
 
@@ -81,12 +86,28 @@ Use width-and-height-constrained type sizing such as `min(vw, vh)` or container 
 
 Also inspect every composition where a light panel is nested inside a dark or saturated spread, and every dark panel nested inside a light spread. Container background changes must explicitly reset the foreground color instead of inheriting it from the parent spread.
 
+Confirm that every spread renders on its own surface and that the fixed navigation chrome is visible on all of them. Step to each spread and check that its background is the intended light or dark field, not the page default showing through, and that no heading, body copy, or evidence text has dropped out against it. Then confirm the navigation controls and page indicators are visible on both the lightest and the darkest spread; controls that only show up over dark spreads are a defect.
+
 Run a computed-style contrast check on rendered text elements before delivery:
 
 - Resolve each text element's effective foreground color and the painted background of its nearest opaque ancestor
 - Flag white or near-white text on white or near-white surfaces, and dark text on dark surfaces
 - Treat text that becomes readable only when selected or highlighted as a hard failure
 - Re-render and visually confirm every flagged spread after fixing it
+
+Confirm every title states its finding:
+
+- Read each chapter, section, and spread title on its own. It must convey the actual finding as an intelligible sentence, or be a short label that is decipherable without the body beneath it.
+- A vague evocative fragment that could sit on any report is a failure. Rewrite it to carry the claim, then re-render.
+
+Confirm the copy frames its findings:
+
+- Read the cover lede and each opening paragraph as a reader who was not on the calls. If a line is true but only decipherable to someone who shared the week's context, it fails. Rewrite it to set the scene and state the point plainly, then keep any clever turn as a follow-on rather than the lead.
+
+Confirm the intended typefaces actually rendered:
+
+- In the rendered screenshot, check that the display and body faces are the ones the composition specifies, not a system fallback. A serif that paints as Georgia or a sans that paints as the default UI font means the font never loaded.
+- Verify computationally where possible: the resolved `font-family` on a heading and on body text should be a loaded face, and `document.fonts` should report it ready. A declared-but-unloaded font is a hard failure. Fix the load or embed, then re-render and confirm the correct face paints.
 
 ## Presentation deck
 
@@ -111,7 +132,7 @@ Hand off to `/octave:microsite`. Favor a scannable landing-page narrative, ancho
 
 ## One-page summary
 
-Hand off to `/octave:one-pager`. Compress to the conclusion, 3–5 key findings, the most credible evidence, and specific recommendations.
+Hand off to `/octave:one-pager`. Compress to the conclusion, 3 to 5 key findings, the most credible evidence, and specific recommendations.
 
 ## Markdown digest
 

--- a/skills/digest/scripts/lint.sh
+++ b/skills/digest/scripts/lint.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Digest mechanical lint — deterministic checks that don't need LLM judgment.
+# Usage: bash lint.sh <path-to-output.html>
+# Returns non-zero exit code if any violations found.
+
+FILE="$1"
+if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
+  echo "Usage: bash lint.sh <path-to-output.html>"
+  exit 1
+fi
+
+VIOLATIONS=0
+
+echo "MECHANICAL LINT"
+echo "==============="
+echo "File: $FILE"
+echo ""
+
+# --- Em-dashes (U+2014) and en-dashes (U+2013) ---
+EMDASH_COUNT=$(grep -o '—' "$FILE" 2>/dev/null | wc -l | tr -d ' ')
+[ -z "$EMDASH_COUNT" ] && EMDASH_COUNT=0
+if [ "$EMDASH_COUNT" -gt 0 ]; then
+  echo "FAIL: $EMDASH_COUNT em-dash(es) found (U+2014). Replace with commas, periods, or \"to\"."
+  grep -n '—' "$FILE" | head -10
+  echo ""
+  VIOLATIONS=$((VIOLATIONS + EMDASH_COUNT))
+fi
+ENDASH_COUNT=$(grep -o '–' "$FILE" 2>/dev/null | wc -l | tr -d ' ')
+[ -z "$ENDASH_COUNT" ] && ENDASH_COUNT=0
+if [ "$ENDASH_COUNT" -gt 0 ]; then
+  echo "FAIL: $ENDASH_COUNT en-dash(es) found (U+2013). Replace with commas, periods, or \"to\"."
+  grep -n '–' "$FILE" | head -10
+  echo ""
+  VIOLATIONS=$((VIOLATIONS + ENDASH_COUNT))
+fi
+
+# --- Double-hyphens used as dashes ---
+# Exclude HTML comments (<!--) and CSS properties
+DOUBLEDASH=$(grep -n '\-\-' "$FILE" | grep -v '<!--' | grep -v '\-\-kit' | grep -v '\-\-brand' | grep -v '\-\-bg' | grep -v '\-\-text' | grep -v '\-\-font' | grep -v '\-\-border' | grep -v '\-\-accent' | grep -v '\-\-on-' | grep -v 'var(--' | grep -v '<style' | grep -v 'css' | grep -c '' 2>/dev/null || echo 0)
+# This check is noisy with CSS custom properties, so skip it for now
+
+# --- Tier 1 banned words ---
+BANNED_WORDS="delve landscape robust comprehensive leverage seamless seamlessly cutting-edge pivotal underscores meticulous meticulously utilize holistic holistically actionable impactful learnings synergy synergies game-changer game-changing tapestry realm paradigm embark beacon"
+for WORD in $BANNED_WORDS; do
+  # Case-insensitive search in text content (skip CSS/JS/HTML tags)
+  COUNT=$(grep -ioP "(?<=>)[^<]*\b${WORD}\b[^<]*(?=<)" "$FILE" 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$COUNT" -gt 0 ]; then
+    echo "FAIL: Banned word '$WORD' found $COUNT time(s)."
+    grep -inP "(?<=>)[^<]*\b${WORD}\b[^<]*(?=<)" "$FILE" | head -5
+    echo ""
+    VIOLATIONS=$((VIOLATIONS + COUNT))
+  fi
+done
+
+# --- Banned phrases ---
+BANNED_PHRASES=(
+  "best practices"
+  "deep dive"
+  "dive into"
+  "at its core"
+  "in order to"
+  "due to the fact that"
+  "serves as"
+  "testament to"
+  "it.s worth noting"
+  "when it comes to"
+  "at the end of the day"
+  "let.s explore"
+  "let.s take a look"
+  "let.s break this down"
+  "here.s what.s interesting"
+  "in today.s"
+  "in an era"
+)
+for PHRASE in "${BANNED_PHRASES[@]}"; do
+  COUNT=$(grep -ioP "(?<=>)[^<]*${PHRASE}[^<]*(?=<)" "$FILE" 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$COUNT" -gt 0 ]; then
+    echo "FAIL: Banned phrase '$PHRASE' found $COUNT time(s)."
+    grep -inP "(?<=>)[^<]*${PHRASE}[^<]*(?=<)" "$FILE" | head -3
+    echo ""
+    VIOLATIONS=$((VIOLATIONS + COUNT))
+  fi
+done
+
+# --- Text density: single <p> tags with 3+ sentences ---
+# Count periods followed by a space and uppercase letter (rough sentence boundary)
+DENSE_BLOCKS=$(grep -oP '<p[^>]*>[^<]{100,}</p>' "$FILE" 2>/dev/null | while read -r line; do
+  SENTENCES=$(echo "$line" | grep -oP '\. [A-Z]' | wc -l | tr -d ' ')
+  SENTENCES=$((SENTENCES + 1))
+  if [ "$SENTENCES" -ge 4 ]; then
+    echo "$line" | head -c 120
+    echo "... ($SENTENCES sentences)"
+  fi
+done)
+if [ -n "$DENSE_BLOCKS" ]; then
+  DENSE_COUNT=$(echo "$DENSE_BLOCKS" | wc -l | tr -d ' ')
+  echo "WARN: $DENSE_COUNT text block(s) with 4+ sentences in a single <p>. Consider splitting."
+  echo "$DENSE_BLOCKS" | head -5
+  echo ""
+fi
+
+# --- Library/Octave internals leaked into reader-facing text ---
+INTERNAL_TERMS="the library|source of truth|entity type|objection entities|use case entities|no .* entities|library says|library doesn.t|Octave internals|findings show|field data indicates|the data shows"
+INTERNAL_COUNT=$(grep -ioP "(?<=>)[^<]*(${INTERNAL_TERMS})[^<]*(?=<)" "$FILE" 2>/dev/null | wc -l | tr -d ' ')
+if [ "$INTERNAL_COUNT" -gt 0 ]; then
+  echo "FAIL: $INTERNAL_COUNT internal reference(s) leaked into reader-facing text."
+  grep -inP "(?<=>)[^<]*(${INTERNAL_TERMS})[^<]*(?=<)" "$FILE" | head -5
+  echo ""
+  VIOLATIONS=$((VIOLATIONS + INTERNAL_COUNT))
+fi
+
+# --- Summary ---
+echo "─────────────────"
+if [ "$VIOLATIONS" -eq 0 ]; then
+  echo "PASS: Zero mechanical violations."
+  exit 0
+else
+  echo "TOTAL VIOLATIONS: $VIOLATIONS"
+  echo "Fix all violations before proceeding to editorial review."
+  exit 1
+fi


### PR DESCRIPTION
## What

Tunes the **digest** skill and bumps the plugin to **2.3.3**.

Two things: sharpen the digest's editorial guidance toward a real "dispatch" voice, and bring its review step up to the same **MANDATORY GATE** the other visual skills (abm, deck, etc.) already run. Live digest was under-wired here.

### Editorial rules (`SKILL.md`, `references/format-routing.md`)
- **Titles must state their finding.** No vague evocative fragments ("The Pressure," "The Wall"), no dramatic clever turns. The editorial review now audits titles the same way it audits prose.
- **"Write like a dispatch, not an inside joke."** Frame each finding for a reader who was not on the calls; no cryptic, elliptical lines that assume shared context.
- **Vary prose cadence** so it doesn't read as machine-written (no uniform before/after or rule-of-three rhythm).
- **Brand typefaces, actually loaded.** Resolve the workspace brand kit first and set the digest in its real faces, self-contained as base64 `@font-face`. Generic type when a kit exists, or a declared-but-unloaded font that falls back to a system face, is a defect.
- **Magazine surfaces & nav.** Every spread declares its own background (otherwise a light spread inherits the dark page background and its text disappears), and the fixed navigation chrome must stay legible on both light and dark spreads.
- Responsive review gate gains: title-states-its-finding, dispatch-framing, per-spread + nav contrast, and typeface-actually-rendered checks.

### Review gate (`SKILL.md`, `scripts/lint.sh`)
- Replaces the soft one-line "run the mandatory review protocol" with the full gate: preflight + lint, two dedicated reviewers (`octave-editorial-reviewer` / `octave-presentation-reviewer`) spawned in parallel, scorecard loop. Mirrors the abm wiring against `../shared/protocol.md`.
- Adds `skills/digest/scripts/lint.sh` (the standard mechanical linter; abm and the other visual skills already ship one).

### Housekeeping
- Converts pre-existing en-dash numeric ranges to "to" for dash hygiene.

## Scope
Digest skill only, plus the version bump in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`. No shared principle docs changed; the skill continues to reference `../shared/…`.

## Testing
- Rebuilt a real horizontal-swipe magazine demo with these rules and confirmed it passes the responsive gate (16:9, 16:10, ultrawide, tablet), renders the correct embedded brand faces, and lints clean.
- The gate wiring itself references existing agents/protocol; it has not been executed end-to-end by the reviewer subagents in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)