### PR TITLE
Add Open Graph tags so published artifacts unfurl

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "octave",
       "source": "./",
       "description": "Access Octave's GTM knowledge base for positioning, research, content generation, and sales enablement",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "author": {
         "name": "Octave",
         "url": "https://octavehq.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octave",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Octave GTM knowledge base integration for Claude Code, OpenAI Codex, and Cursor — provides bidirectional access to personas, Motions, messaging, and more. Give your AI grounded context for your GTM motions.",
   "author": {
     "name": "Octave",

--- a/skills/abm/references/html-scaffold.md
+++ b/skills/abm/references/html-scaffold.md
@@ -2,7 +2,7 @@
 
 The proven, self-contained scaffold for the six-job account plan (locked from the Coinbase v2 build). Reproduce this structure and card vocabulary. Content specifics come from `account-plan-template.md`; brand tokens come from the workspace company's cached kit.
 
-**Rules:** self-contained (inline CSS/JS, only Google Fonts external). No em-dashes or en-dashes. The `:root` brand block is inlined from `~/.octave/brands/<workspace-slug>/tokens.css` plus `get-brand-components/assets/kit_base.css`; the semantic + component CSS below is the reusable scaffold. Six sections in order, conclusion-carrying headers, sidebar nav dots, persona selector in section 5, print flattening.
+**Rules:** self-contained (inline CSS/JS, only Google Fonts external). No em-dashes or en-dashes. The `:root` brand block is inlined from `~/.octave/brands/<workspace-slug>/tokens.css` plus `get-brand-components/assets/kit_base.css`; the semantic + component CSS below is the reusable scaffold. Six sections in order, conclusion-carrying headers, sidebar nav dots, persona selector in section 5, print flattening. The head carries the social share block (rules in [../../shared/social-meta.md](../../shared/social-meta.md)); `assets/og.png` is the one permitted sibling file.
 
 ## `<head>` + `<style>`
 
@@ -10,6 +10,10 @@ The proven, self-contained scaffold for the six-job account plan (locked from th
 <!DOCTYPE html><html lang="en"><head>
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Account Plan: [Company]</title>
+<meta property="og:title" content="Account Plan: [Company]">
+<meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+<meta property="og:image" content="assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=[kit fonts]&display=swap" rel="stylesheet">

--- a/skills/ads-resonance/references/prediction-dashboard-template.md
+++ b/skills/ads-resonance/references/prediction-dashboard-template.md
@@ -55,6 +55,10 @@ The dashboard should feel like a modest internal tool — dense but not crowded,
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Prediction Dashboard — {account} — {date}</title>
+<meta property="og:title" content="Prediction Dashboard: {account}">
+<meta property="og:description" content="{one plain sentence on what this dashboard shows}">
+<meta property="og:image" content="assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   :root {

--- a/skills/ads-resonance/references/resonance-report-template.md
+++ b/skills/ads-resonance/references/resonance-report-template.md
@@ -77,6 +77,10 @@ Save to `~/Desktop/resonance-report-<workspace-slug>-<YYYY-MM-DD>.html`. Tell th
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Resonance Report — {workspace} — {window}</title>
+<meta property="og:title" content="Resonance Report: {workspace}">
+<meta property="og:description" content="{one plain sentence on what this report covers}">
+<meta property="og:image" content="assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   :root {

--- a/skills/ads/references/html-deck-template.md
+++ b/skills/ads/references/html-deck-template.md
@@ -1,6 +1,6 @@
 # Visual Campaign Deck — HTML Template
 
-When the user chooses **Generate visual campaign deck**, ask where they'd like the file saved (suggest `~/Desktop/` as a default). Produce a self-contained HTML file named after the campaign.
+When the user chooses **Generate visual campaign deck**, ask where they'd like the file saved (suggest `~/Desktop/` as a default). Produce a self-contained HTML file named after the campaign. The head carries the social share block (og:title + og:description always, relative og:image when published; canonical block in [../../shared/social-meta.md](../../shared/social-meta.md)).
 
 ## Deck Structure
 

--- a/skills/asset-manager/SKILL.md
+++ b/skills/asset-manager/SKILL.md
@@ -17,11 +17,12 @@ Every asset has exactly one `privacy` tier — each is strictly more open than t
 | `workspace` *(default)* | Owner + workspace members — a teammate opening the link verifies their work email once, then sees everything their team has shared |
 | `public` | Anyone with the URL |
 
-Three more facts complete the model:
+Four more facts complete the model:
 
 - `status` is a separate axis: `published` (default; discoverable in the workspace gallery) vs `unpublished` (hidden, but still viewable via preview/workspace links). Status never affects the privacy tier.
 - **"Externally shared" is not a tier.** Share links (emails/domains + verification) work on any non-`public` asset; the API reports the derived `externallyShared: true` on an asset that has at least one share link. Creating or revoking shares never changes `privacy`.
 - **Locked-out viewers can knock.** A code-verified visitor who hits an asset they can't open (workspace or share flow) can request access; those requests land in the owner's inbox (see Access Requests workflow).
+- **Only `public` unfurls.** Link-preview cards (Slack/LinkedIn/X) render only for `public` website assets opened via `siteUrl`: crawlers cannot pass the workspace email wall, and share links are crawler-blocked by design. Unfurl fetches never count in visit stats. The service absolutizes a relative `og:image` and injects `twitter:card` at serve time, but it cannot invent missing tags or a missing image file — that's the unfurl check in the publish workflow below (rules in [social-meta.md](../shared/social-meta.md)).
 
 **Link lifetimes:** share links never expire by default (expiry is opt-in per share); a viewer's verified session and a `previewUrl` each last ~30 days. Rule of thumb: hand out a `previewUrl` for a teammate's quick look, a share link for an external "review this deck" — neither will rot mid-conversation. Revoking a share still cuts access immediately.
 
@@ -156,10 +157,11 @@ Script gotcha: metadata values are interpolated into JSON **without escaping** �
    - First — identifier: offer your suggestion first (`<suggestion> (Recommended)`), 1-2 sensible alternates; the user can always type their own via Other.
    - Second — one question: **privacy**.
      - `Workspace (Recommended)` — "Your team can find, open, and reuse it — this is what makes the asset cache work."
-     - `Public` — "Anyone with the URL can view."
+     - `Public` — "Anyone with the URL can view. Link previews (unfurl cards) render only on this tier."
      - `Only me` — "Just you; others need a share link."
      Status is NOT asked — default `published`. Only mention `unpublished` if the user says "draft"/"not ready yet" (set it via `--status unpublished` or later via `asset_update`).
 5. **Draft the description.** 1-2 sentences saying what the asset is and who it's for (e.g. "Interactive use-case explorer for Acme's platform, built for the Q3 ABM campaign"). Sanitize for the script (no `"` or `\`).
+5b. **Unfurl check (public websites only).** If `--type website` and the user chose `public`: grep the entry point for `og:title`, `og:description`, and `og:image`, and check the `og:image` target exists in the source folder. Anything missing → offer once: "Want this to unfurl with a preview card when the link is posted? I'll add share metadata (plus a 1200×630 share image, ~30s)." Yes → add the head block from [social-meta.md](../shared/social-meta.md); render a missing image via the get-brand-components OG chain into `<src>/assets/og.png`. Missing title/description alone → fill them from the page's own `<title>` and lede, no render needed. Non-public tiers → skip silently (cards can't render there anyway). All local grep/edit/render — no MCP calls, so it sits safely before the mint.
 6. **Mint the token** (`asset_generate_access_token`) and resolve the base URL. Do this AFTER steps 1-5 — the step-2 `assets_list` already rotated any earlier token, and no MCP asset calls may follow the mint before the upload runs.
 7. **Upload.**
    - Source is already a `.zip` → `upload-artifact.sh --src <file>.zip ...`
@@ -176,6 +178,7 @@ Script gotcha: metadata values are interpolated into JSON **without escaping** �
 1. assets_list                    ← MCP tool call (Cache Rule)
 2. AskUserQuestion (identifier)   ← offer suggestion + alternates
 3. AskUserQuestion (privacy)      ← workspace (recommended) | public | only_me
+3b. (public websites) unfurl check ← local grep for og tags + optional assets/og.png render; no MCP calls
 4. asset_generate_access_token    ← MCP tool call; capture accessToken from the result
 5. ONE bash command               ← ARTIFACTS_ACCESS_TOKEN='<accessToken>' \
                                       bash "${CLAUDE_PLUGIN_ROOT:-.}"/skills/asset-manager/scripts/zip-and-upload-artifact.sh \
@@ -183,7 +186,7 @@ Script gotcha: metadata values are interpolated into JSON **without escaping** �
 6. Update the registry, report the link
 ```
 
-A publish that creates more than one asset, or runs any script outside the bundled four, is off the rails — stop and restart from this sequence. (The documented recoveries are NOT off the rails: the `zip → upload-artifact.sh` per-file fallback when zipping fails, and a single 401/502 retry, each stay within this one publish.)
+A publish that creates more than one asset, or runs any script outside the bundled four, is off the rails — stop and restart from this sequence. (The documented recoveries are NOT off the rails: the `zip → upload-artifact.sh` per-file fallback when zipping fails, a single 401/502 retry, and the step-3b unfurl check's get-brand-components render scripts — each stays within this one publish.)
 
 ## Workflow: Update an Asset's Files
 
@@ -220,7 +223,7 @@ For identifier, description, entry point, privacy, status, or vanity slug change
   2. `only_me`: everyone but the owner loses access — teammates too (no API read, no preview).
   3. Anyone else needs a **share link** (emails and/or allowed domains, email-verified) — works on any non-public tier.
   Then ask WHO to share with (emails/domains) and whether the link should ever expire (default: never) → Shares workflow. Report the fresh `previewUrl` for teammates alongside the share link.
-- **When flipping to `public`**, mention existing share links keep working but are no longer needed.
+- **When flipping to `public`**, mention existing share links keep working but are no longer needed. For website assets, run the same unfurl check as publish step 5b first: grep for the og tags and the og:image file, and if anything is missing offer to add the share block and `assets/og.png` via a file update before the flip — public is the only tier where cards render.
 
 ## Workflow: Vanity URLs
 

--- a/skills/battlecard-doc/references/html-architecture.md
+++ b/skills/battlecard-doc/references/html-architecture.md
@@ -12,6 +12,7 @@ Self-contained HTML with a dark "sheet" container on a black body. Design modele
 - **Comparison grids** for side-by-side competitive content
 - **Eyebrow labels** for section categorization
 - **No emoji** -- use CSS-based indicators (colored borders, markers)
+- **Share metadata in `<head>`** -- og:title + og:description on every output, relative og:image when published; canonical block in [../../shared/social-meta.md](../../shared/social-meta.md)
 
 ## CSS Variable System
 

--- a/skills/champion-deal-room/references/html-scaffold.md
+++ b/skills/champion-deal-room/references/html-scaffold.md
@@ -1,6 +1,6 @@
 # Champion Deal-Room HTML Scaffold
 
-Implements [../../shared/formats/html-document.md](../../shared/formats/html-document.md) (scroll-based reading flow, sticky nav, card-based containers, print flattening) and [../../shared/presentation-principles.md](../../shared/presentation-principles.md) (universal visual rules) for this skill's specific case: a dense, self-contained working document in the meeting-prep battle-plan style: sticky sidebar nav dots, collapsible `details` sections (open by default, forced open on print), and a real card vocabulary. Styled with the workspace company's brand kit (inline `tokens.css` `:root` + the brand's Google Fonts). No external requests beyond Google Fonts.
+Implements [../../shared/formats/html-document.md](../../shared/formats/html-document.md) (scroll-based reading flow, sticky nav, card-based containers, print flattening) and [../../shared/presentation-principles.md](../../shared/presentation-principles.md) (universal visual rules) for this skill's specific case: a dense, self-contained working document in the meeting-prep battle-plan style: sticky sidebar nav dots, collapsible `details` sections (open by default, forced open on print), and a real card vocabulary. Styled with the workspace company's brand kit (inline `tokens.css` `:root` + the brand's Google Fonts). No external requests beyond Google Fonts. The head carries the social share block (rules in [../../shared/social-meta.md](../../shared/social-meta.md)); `assets/og.png` is the one permitted sibling file.
 
 This is NOT a full-viewport scrolling landing page. It is a max-900px document column with information density. Reproduce this structure and vocabulary.
 
@@ -11,6 +11,10 @@ This is NOT a full-viewport scrolling landing page. It is a max-900px document c
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Deal Room: [Company] — [Workspace Company]</title>
+<meta property="og:title" content="Deal Room: [Company]">
+<meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+<meta property="og:image" content="assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=[fonts]&display=swap" rel="stylesheet">

--- a/skills/deal-coach/references/html-scaffold.md
+++ b/skills/deal-coach/references/html-scaffold.md
@@ -11,6 +11,10 @@ Self-contained, single HTML file. The only external dependency is Google Fonts (
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Deal Coaching: [Company] · Resonate → Elevate → Compel</title>
+<meta property="og:title" content="Deal Coaching: [Company]">
+<meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+<meta property="og:image" content="assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/skills/deck/references/html-scaffold.md
+++ b/skills/deck/references/html-scaffold.md
@@ -13,6 +13,11 @@ The full contents of [`viewport-base.css`](viewport-base.css) are **mandatory** 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>[Deck Title]</title>
+  <!-- Social share (link unfurl) metadata -->
+  <meta property="og:title" content="[Deck Title]">
+  <meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+  <meta property="og:image" content="assets/og.png">
+  <meta name="twitter:card" content="summary_large_image">
   <!-- Google Fonts (preconnect + stylesheet) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/skills/get-brand-components/SKILL.md
+++ b/skills/get-brand-components/SKILL.md
@@ -484,11 +484,18 @@ python3 <skill-dir>/scripts/render_kit.py --kit <slug|path> --spec <content.json
 - `--kit-dir` renders a kit stored anywhere (kits don't have to live in `~/.octave/brands/`).
 - `--theme` picks the light or dark palette when the kit carries both (`tokensDark`/`tokensLight`).
 
-### Output formats (optional — ask the user)
+### Output formats
 
 The same kit + spec can render to **multiple formats** — the brand kit is format-agnostic, so don't rebuild styling per format. `--format` sets the canvas: `doc` (default page), `og` (1200×630 share image), `social-square` (1080²), `social-story` (1080×1920), `email` (600px width). The *spec* controls content (a short hero/CTA spec makes a clean OG/social image).
 
-**Don't generate format variants by default** — they cost extra renders and the user usually wants just the doc. After producing the main asset, **ask** whether they also want any format variants (e.g. an OG image, a square social tile), and only then render them.
+**The OG share image is automatic at publish; every other variant is ask-first.** When an HTML deliverable is headed somewhere anyone with the link can open it — the asset-manager `public` tier, the microsite deploy, or the user saying at intake they'll publish, post, or share the link — render its share image without asking and place it beside the HTML:
+
+```bash
+python3 <skill-dir>/scripts/render_kit.py --kit <slug> --spec og-spec.json --format og --out og-frame.html
+python3 <skill-dir>/scripts/render.py --file og-frame.html --out <deliverable-dir>/assets/og.png --width 1200 --height 630 --scale 1
+```
+
+The spec is one `hero` block carrying the deliverable's headline and a one-line subhead — write both fresh from the deliverable and hold them to editorial-rules.md; this copy renders on the social card. Delete `og-frame.html` after. Then confirm the deliverable's head references the image relatively (`assets/og.png`) with the block from [social-meta.md](../shared/social-meta.md) — never an absolute URL, never a data URI. Square, story, and email variants stay opt-in: after producing the main asset, ask whether the user wants them, and only then render.
 
 - **`scripts/render_kit.py`** — loads the kit, emits a self-contained HTML doc: `<style>` = `:root{}` from `manifest.render.tokens` + base64 `@font-face` from `manifest.render.fonts` + `assets/kit_base.css`; body = composed blocks; logo/icons inlined.
 - **`assets/kit_base.css`** — brand-AGNOSTIC component stylesheet (every rule references a `--brand-*` token). This is the single source of truth for component CSS — fix a component once here and every asset for every brand inherits it.

--- a/skills/get-brand-components/scripts/render_kit.py
+++ b/skills/get-brand-components/scripts/render_kit.py
@@ -347,6 +347,10 @@ def main():
                     help="render a specific theme (needs manifest.render.tokensDark/tokensLight overrides)")
     ap.add_argument("--format", default="doc",
                     help="output canvas: doc (default) | og (1200x630) | social-square (1080) | social-story (1080x1920) | email (600w)")
+    ap.add_argument("--og-desc", dest="og_desc",
+                    help="emit social share metas: og:title (from spec title) + this og:description")
+    ap.add_argument("--og-image", dest="og_image",
+                    help="RELATIVE og:image path (e.g. assets/og.png); also emits twitter:card. Requires --og-desc")
     args = ap.parse_args()
     target = args.kit_dir or args.kit
     if not target:
@@ -412,9 +416,17 @@ def main():
     link = (f'<link rel="preconnect" href="https://fonts.googleapis.com">'
             f'<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>'
             f'<link href="{html.escape(wf)}" rel="stylesheet">') if wf else ""
+    # social share metas, opt-in: --format og intermediates must never carry their own OG tags
+    og = ""
+    if args.og_desc:
+        og = (f'<meta property="og:title" content="{title}">'
+              f'<meta property="og:description" content="{html.escape(args.og_desc)}">')
+        if args.og_image:
+            og += (f'<meta property="og:image" content="{html.escape(args.og_image)}">'
+                   f'<meta name="twitter:card" content="summary_large_image">')
     doc = (f'<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">'
            f'<meta name="viewport" content="width=device-width,initial-scale=1"><title>{title}</title>'
-           f'{link}<style>{style}</style></head><body><div class="doc">{"".join(parts)}</div></body></html>')
+           f'{og}{link}<style>{style}</style></head><body><div class="doc">{"".join(parts)}</div></body></html>')
     pathlib.Path(args.out).write_text(doc, encoding="utf-8")
     print(args.out, f"({len(doc)} bytes)")
 

--- a/skills/meeting-prep/SKILL.md
+++ b/skills/meeting-prep/SKILL.md
@@ -1265,6 +1265,11 @@ Section 5 uses a `<section>` element (not `<details>`) since it's always visible
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Meeting Prep: [Company] — [Meeting Type]</title>
+  <!-- Social share (link unfurl) metadata -->
+  <meta property="og:title" content="Meeting Prep: [Company]">
+  <meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+  <meta property="og:image" content="assets/og.png">
+  <meta name="twitter:card" content="summary_large_image">
   <!-- Google Fonts (preconnect + stylesheet) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/skills/meeting-prep/references/html-scaffold.md
+++ b/skills/meeting-prep/references/html-scaffold.md
@@ -7,6 +7,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Battle Plan: [Company] — [Meeting Type]</title>
+  <!-- Social share (link unfurl) metadata -->
+  <meta property="og:title" content="Battle Plan: [Company]">
+  <meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+  <meta property="og:image" content="assets/og.png">
+  <meta name="twitter:card" content="summary_large_image">
   <!-- Google Fonts (preconnect + stylesheet) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/skills/microsite/SKILL.md
+++ b/skills/microsite/SKILL.md
@@ -188,7 +188,7 @@ These rules are non-negotiable for microsites:
 4. **One CTA, repeated** — the same ask in the hero (subtle) and the closing section (prominent). Do not confuse with multiple different asks.
 5. **Mobile-first** — this WILL be opened from email on a phone. All `clamp()` values must work at 375px width. Test aggressively.
 6. **No sidebar, no navigation bar** — single vertical scroll. Smooth, clean, focused.
-7. **Self-contained** — inline CSS, no external requests beyond Google Fonts. NO tracking pixels, analytics, or third-party scripts.
+7. **Self-contained** — inline CSS, no external requests beyond Google Fonts. NO tracking pixels, analytics, or third-party scripts. Exception: `assets/og.png`, the social share image, ships as a sibling file (unfurlers ignore data-URI og:image); reference it relatively per [social-meta.md](../shared/social-meta.md).
 
 #### Content Density Limits
 
@@ -353,6 +353,7 @@ Size:   [file size]
 
 How to share:
 • Live URL (recommended): bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/deploy.sh .octave-microsites/<company>-<date>/  — deploys to Vercel and returns a public link to drop in your outreach
+  (Vercel serves files verbatim, with none of the asset service's serve-time OG rewriting. After the first deploy returns the URL, set og:image to the absolute <url>/assets/og.png and deploy once more; strict unfurlers like LinkedIn and Facebook require an absolute image URL there. This is a post-gate delivery step: the review gate lints the relative form, and a re-lint of the Vercel copy failing on the absolute-URL check is expected.)
 • PDF: bash "${CLAUDE_PLUGIN_ROOT:-.}"/scripts/export-pdf.sh .octave-microsites/<company>-<date>/<company>-microsite.html  — or Cmd+P / Ctrl+P -> Save as PDF
 • Host on any static file server, S3 bucket, or Netlify drop
 • Or send the HTML file directly as an attachment

--- a/skills/microsite/references/html-architecture.md
+++ b/skills/microsite/references/html-architecture.md
@@ -7,6 +7,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Built for [Company] | [Your Company]</title>
+  <!-- Social share (link unfurl) metadata -->
+  <meta property="og:title" content="Built for [Company] | [Your Company]">
+  <meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+  <meta property="og:image" content="assets/og.png">
+  <meta name="twitter:card" content="summary_large_image">
   <!-- Google Fonts (preconnect + stylesheet) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/skills/one-pager/references/html-architecture.md
+++ b/skills/one-pager/references/html-architecture.md
@@ -7,6 +7,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>[One-Pager Title]</title>
+  <!-- Social share (link unfurl) metadata -->
+  <meta property="og:title" content="[One-Pager Title]">
+  <meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+  <meta property="og:image" content="assets/og.png">
+  <meta name="twitter:card" content="summary_large_image">
   <!-- Google Fonts (preconnect + stylesheet) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/skills/positioning/references/html-scaffold.md
+++ b/skills/positioning/references/html-scaffold.md
@@ -7,6 +7,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Positioning System: [Product/Company]</title>
+  <meta property="og:title" content="Positioning System: [Product/Company]">
+  <meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+  <meta property="og:image" content="assets/og.png">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=[fonts]&display=swap" rel="stylesheet">

--- a/skills/proposal/references/html-architecture.md
+++ b/skills/proposal/references/html-architecture.md
@@ -11,6 +11,10 @@ The proposal uses the same CSS variable system as `/octave:deck` (see the shared
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>[Proposal Title] - [Company Name]</title>
+  <meta property="og:title" content="[Proposal Title]: [Company Name]">
+  <meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+  <meta property="og:image" content="assets/og.png">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=[fonts]&display=swap" rel="stylesheet">

--- a/skills/research/references/brief-html-architecture.md
+++ b/skills/research/references/brief-html-architecture.md
@@ -7,6 +7,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Account Brief: [Company] — [Occasion]</title>
+  <!-- Social share (link unfurl) metadata -->
+  <meta property="og:title" content="Account Brief: [Company]">
+  <meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+  <meta property="og:image" content="assets/og.png">
+  <meta name="twitter:card" content="summary_large_image">
   <!-- Google Fonts (preconnect + stylesheet) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/skills/shared/formats/html-document.md
+++ b/skills/shared/formats/html-document.md
@@ -44,3 +44,4 @@ node <skill-dir>/../shared/scripts/render-gate.js <document.html> \
 - [ ] **Modals (if present) accessible.** Close on Escape, close on backdrop click, `aria-label` on close button, `body` overflow hidden when open.
 - [ ] **Print flattens.** `@media print` block: tabs become labeled blocks via `data-tab-label`, modals expand inline, dark inverts to light, nav hidden, cards get `break-inside: avoid`.
 - [ ] **Footer complete.** Data window, generation date, confidentiality notice, branding: all present and consistent with header.
+- [ ] **Share metadata.** og:title and og:description present and filled. og:image, when present, is a relative path to a real sibling file (assets/og.png); no og:url or canonical. See [social-meta.md](../social-meta.md).

--- a/skills/shared/formats/magazine.md
+++ b/skills/shared/formats/magazine.md
@@ -10,7 +10,7 @@ These principles supplement the universal visual rules in `presentation-principl
 
 Create a single horizontal-swipe HTML file:
 
-- **Emit a complete standalone document**: `<!DOCTYPE html>`, `<html lang="en">`, `<meta charset="utf-8">`, `<head>`, `<body>`. A magazine is served as-is by the asset service, not injected into a host page, so nothing supplies these for you. Without the doctype the browser renders in quirks mode, where `<table>` does not inherit `color` from its ancestor: a correct dark-spread stylesheet then paints body ink on a dark field and the table silently disappears. Belt and braces, `magazine-base.css` sets `color: inherit` on tables inside spreads.
+- **Emit a complete standalone document**: `<!DOCTYPE html>`, `<html lang="en">`, `<meta charset="utf-8">`, `<head>`, `<body>`, plus the social share block from [social-meta.md](../social-meta.md) (`og:title`, `og:description`; relative `og:image` when published). A magazine is served as-is by the asset service, not injected into a host page, so nothing supplies these for you. Without the doctype the browser renders in quirks mode, where `<table>` does not inherit `color` from its ancestor: a correct dark-spread stylesheet then paints body ink on a dark field and the table silently disappears. Belt and braces, `magazine-base.css` sets `color: inherit` on tables inside spreads.
 - Each spread is `100vw × 100vh`
 - Horizontal scroll snap, no vertical page scrolling
 - Full-bleed, edge-to-edge editorial compositions
@@ -144,7 +144,7 @@ Confirm the intended typefaces actually rendered:
 
 Format-specific audit for swipe magazines. Run alongside the universal presentation checklist. Run the render gate first (invocation above).
 
-- [ ] **Standalone document.** Doctype, `html lang`, charset, head, body all present; no host-page assumptions.
+- [ ] **Standalone document.** Doctype, `html lang`, charset, head, body all present; no host-page assumptions. Share metadata present per [social-meta.md](../social-meta.md); a published magazine's `og.png` sits beside the file (the deliverable becomes a small folder) and `og:image` stays relative.
 - [ ] **Base scaffold present.** The full `magazine-base.css` contents are in the `<style>` block; spreads use `.spread` with an explicit `.is-light` / `.is-dark` (or equivalent declared surface+ink pair).
 - [ ] **No vertical page scroll; every spread fits.** Content fits inside `100vh` minus the nav band at all four gate viewports.
 - [ ] **Chrome legible on every spread.** Nav and folio hold contrast on the lightest and darkest spread; nothing renders under the nav band.

--- a/skills/shared/formats/microsite.md
+++ b/skills/shared/formats/microsite.md
@@ -24,7 +24,7 @@ These principles supplement the universal visual rules in `presentation-principl
 
 8. **Personalization is visible.** If built for a specific account, the personalization should be obvious: their name, their industry context, their challenges. Generic-feeling microsites miss the point of ABM.
 
-9. **Fast and self-contained.** No external JS frameworks, no heavy assets. The page should load instantly. All CSS/JS inline. Images as data URIs or inline SVGs.
+9. **Fast and self-contained.** No external JS frameworks, no heavy assets. The page should load instantly. All CSS/JS inline. Images as data URIs or inline SVGs. One exception: the social share image. `og:image` must reference a real file at a relative path (`assets/og.png`) beside `index.html`, because unfurlers ignore `data:` URIs, so the deliverable ships as a two-file folder when it carries one. See [social-meta.md](../social-meta.md).
 
 ---
 
@@ -45,5 +45,6 @@ node <skill-dir>/../shared/scripts/render-gate.js <microsite.html> \
 - [ ] **Responsive.** Content stacks cleanly at 375px viewport width. No horizontal scroll on mobile. Touch targets >= 44px.
 - [ ] **Social proof present.** At least one form of external validation (quote, logo, stat, case reference).
 - [ ] **Personalization visible.** Company name, industry context, or specific challenges referenced, not generic boilerplate.
-- [ ] **Self-contained.** No external CSS/JS dependencies beyond Google Fonts. All assets inline.
+- [ ] **Self-contained.** No external CSS/JS dependencies beyond Google Fonts. All assets inline (`assets/og.png` is the one permitted sibling file).
+- [ ] **Share metadata complete.** og:title, og:description, a relative og:image (`assets/og.png`) that exists on disk, and twitter:card all present. A microsite exists to be linked, so the image is required here, not optional. See [social-meta.md](../social-meta.md).
 - [ ] **Print works.** Readable when printed, even if simplified. Interactive elements flatten.

--- a/skills/shared/formats/one-pager.md
+++ b/skills/shared/formats/one-pager.md
@@ -55,3 +55,4 @@ node <skill-dir>/../shared/scripts/render-gate.js <one-pager.html> --viewports 1
 - [ ] **Co-branding present.** Customer logo and Octave branding visible and professional.
 - [ ] **CTA visible.** Next steps or call to action prominent, not buried.
 - [ ] **No overflow.** No content clipped or hidden at page boundaries when printed.
+- [ ] **Share metadata.** og:title and og:description present and filled. og:image, when present, is a relative path to a real sibling file (assets/og.png); no og:url or canonical. See [social-meta.md](../social-meta.md).

--- a/skills/shared/formats/slide-deck.md
+++ b/skills/shared/formats/slide-deck.md
@@ -185,3 +185,4 @@ Fix everything it reports before opening a screenshot. Do not substitute a `scro
 - [ ] **Three font sizes max per slide.** Each slide uses at most three distinct font sizes. If you count more, consolidate: too many sizes creates visual noise.
 - [ ] **Source notes (where applicable).** Slides citing specific quantitative data have a small source attribution. Not needed for qualitative observations or obvious context.
 - [ ] **Print works.** Each slide renders as one page. No content lost or cropped.
+- [ ] **Share metadata.** og:title and og:description present and filled. og:image, when present, is a relative path to a real sibling file (assets/og.png); no og:url or canonical. See [social-meta.md](../social-meta.md).

--- a/skills/shared/protocol.md
+++ b/skills/shared/protocol.md
@@ -28,7 +28,7 @@ Check for:
 - **Scrollbars.** Themed, never the bare default OS scrollbar on a styled surface.
 - **Leaked internals and placeholders.** No tool or function names, version or stream IDs, or unfilled `[…]` brackets anywhere in the rendered output.
 
-Then run the shared lint script. These are deterministic checks (banned words, text density, leaked internals, standalone-document structure, self-containment) that don't need LLM judgment and cost nothing.
+Then run the shared lint script. These are deterministic checks (banned words, text density, leaked internals, standalone-document structure, social share metadata, self-containment) that don't need LLM judgment and cost nothing.
 
 ```bash
 bash <skill-dir>/../shared/scripts/lint.sh <path-to-file>
@@ -205,4 +205,5 @@ Status: [CLEAN / N remaining issues]
 - **Skill-specific blueprints add the most specific layer.** They handle CSS component systems, HTML scaffolds, and structural requirements unique to your skill. These sit on top of the universal + format layers.
 - **The lint script is shared.** One implementation lives at `shared/scripts/lint.sh`; its word and phrase lists mirror editorial-rules.md, so update both together. Don't copy it into a skill. A skill only adds its own `scripts/lint.sh` when it has genuinely skill-specific deterministic checks, and that script runs in addition to the shared one.
 - **So is the render gate.** `shared/scripts/render-gate.js` is format-agnostic: point `--panes` and `--chrome` at whatever the skill's output uses. Prefer extending it over writing a one-off checker, because the failure mode of a hand-rolled one is a false pass, not a crash.
+- **Every artifact carries share metadata.** `og:title` and `og:description` are part of every scaffold head; a deliverable published public also needs a relative `assets/og.png` plus `twitter:card`, or the link never unfurls into a card. The canonical block, the relative-path rule, and the image-render chain live in [social-meta.md](social-meta.md); the lint enforces the deterministic parts, but the card copy itself is attribute text the lint cannot read, so reviewers hold it to editorial-rules.md.
 - **Principles are baked into generation.** The review pass catches what slipped through. It's not the only quality gate: it's the verification gate.

--- a/skills/shared/scripts/lint.sh
+++ b/skills/shared/scripts/lint.sh
@@ -166,6 +166,73 @@ if ! grep -q -i -E -- '<meta[^>]*charset=' "$FILE"; then
   echo ""
 fi
 
+# --- Social share (unfurl) metadata ---
+# A published artifact gets unfurled by Slack/LinkedIn/X crawlers, which build the
+# preview card from Open Graph tags. og:title and og:description cost nothing, so
+# every deliverable carries them. og:image must be a RELATIVE path to a real
+# sibling file (assets/og.png): unfurlers ignore data: URIs, and an absolute URL
+# bakes in the authoring machine's origin; the asset service absolutizes relative
+# paths at serve time. Attribute text is stripped from the reader-facing checks
+# above, so these run on the raw file. Rules + image chain: shared/social-meta.md.
+for TAG in og:title og:description; do
+  TAG_LINE=$(grep -o -i -E -- "<meta[^>]*property=\"$TAG\"[^>]*>" "$FILE" 2>/dev/null | head -1)
+  if [ -z "$TAG_LINE" ]; then
+    echo "FAIL: No $TAG meta tag. Add <meta property=\"$TAG\" content=\"...\"> after"
+    echo "      <title> (canonical block in shared/social-meta.md)."
+    echo ""
+    VIOLATIONS=$((VIOLATIONS + 1))
+  elif echo "$TAG_LINE" | grep -q -i -E -- 'content="(\[[^"]*\]|\{[^"]*\})?"'; then
+    echo "FAIL: $TAG content is empty or an unfilled placeholder."
+    echo "$TAG_LINE"
+    echo ""
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+done
+
+OG_IMG_TAG=$(grep -o -i -E -- '<meta[^>]*property="og:image"[^>]*>' "$FILE" 2>/dev/null | head -1)
+if [ -z "$OG_IMG_TAG" ]; then
+  echo "WARN: No og:image. Fine for an internal doc; anything published public needs one"
+  echo "      for the preview card (relative assets/og.png, see shared/social-meta.md)."
+  echo ""
+else
+  OG_IMG_SRC=$(echo "$OG_IMG_TAG" | sed -E 's/.*content="([^"]*)".*/\1/')
+  case "$OG_IMG_SRC" in
+    data:*)
+      echo "FAIL: og:image is a data: URI. Unfurlers ignore it; point at a real relative"
+      echo "      file (assets/og.png) instead."
+      echo ""
+      VIOLATIONS=$((VIOLATIONS + 1)) ;;
+    http://*|https://*|//*)
+      echo "FAIL: og:image is an absolute URL ($OG_IMG_SRC). That bakes in the authoring"
+      echo "      origin. Use a relative path; the service absolutizes it at serve time."
+      echo ""
+      VIOLATIONS=$((VIOLATIONS + 1)) ;;
+    /*)
+      echo "FAIL: og:image is root-absolute ($OG_IMG_SRC). Artifacts serve under"
+      echo "      /sites/<id>/, so a leading-slash path 404s. Use a relative path."
+      echo ""
+      VIOLATIONS=$((VIOLATIONS + 1)) ;;
+    ""|"<"*|"["*|"{"*)
+      echo "FAIL: og:image content is empty, an unfilled placeholder, or malformed."
+      echo "$OG_IMG_TAG"
+      echo ""
+      VIOLATIONS=$((VIOLATIONS + 1)) ;;
+    *)
+      if [ ! -f "$(dirname "$FILE")/$OG_IMG_SRC" ]; then
+        echo "WARN: og:image points at $OG_IMG_SRC but no such file exists next to the HTML."
+        echo "      Render it before publishing (chain in shared/social-meta.md), or drop"
+        echo "      the og:image line if this deliverable will never be published."
+        echo ""
+      fi ;;
+  esac
+fi
+
+if grep -q -i -E -- 'property="og:url"|rel="canonical"' "$FILE"; then
+  echo "WARN: og:url / rel=canonical present. Omit both: the asset service derives the"
+  echo "      real URL, and an authored one can bake in a wrong origin or path."
+  echo ""
+fi
+
 # --- Self-containment: no external requests ---
 # A hosted artifact runs behind a strict CSP and may be opened offline. Remote
 # fonts, scripts, and images are the most common way a shipped asset degrades.

--- a/skills/shared/social-meta.md
+++ b/skills/shared/social-meta.md
@@ -1,0 +1,68 @@
+# Social share metadata: making artifacts unfurl
+
+Shared reference for every skill that emits HTML. When a link to a published artifact is pasted into Slack, LinkedIn, X, Facebook, or WhatsApp, the platform's crawler fetches the page and builds a preview card from its Open Graph tags. Without them the card degrades to a bare `<title>` at best. The tags cost four lines; author them in every deliverable.
+
+## What the asset service does (and cannot do)
+
+The artifact service meets unfurlers halfway, on **published + `public` website assets only**:
+
+- Named social crawlers are allowed on the site-serving surfaces. Share links stay crawler-blocked by design, and nothing is search-indexable.
+- A **relative** `og:image` path is absolutized at serve time against the real origin. A wrong authoring-time origin (e.g. `http://localhost:3015/...`) is swapped for the real one, but only the origin, never the path, and only for URLs pointing at that artifact.
+- `twitter:card: summary_large_image` is injected automatically when an `og:image` exists and no card is declared.
+- Unfurl fetches are not counted as visits, so pasting a link into a channel doesn't inflate stats.
+
+What it cannot do: invent a missing tag, write your description, or conjure a missing image file. That is authoring-time work, which is why the canonical block below is part of every scaffold head and the mechanical lint checks for it.
+
+## The canonical block
+
+Immediately after `<title>` in the `<head>`:
+
+```html
+<meta property="og:title" content="[What this is and who it is for, in plain language]">
+<meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+<meta property="og:image" content="assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+```
+
+## Rules
+
+1. **`og:title` and `og:description` go on every HTML deliverable.** They cost nothing and survive a later privacy flip to `public` without a re-edit. This copy renders on the social card, so it is reader-facing: hold it to [editorial-rules.md](editorial-rules.md) even though the mechanical lint cannot see attribute text (its text extraction strips tags). No unfilled placeholders, no internal framing, no em dashes.
+
+2. **`og:image` is always a RELATIVE path** (`assets/og.png`), never anything else:
+   - Never a `data:` URI. Every unfurler ignores it, and the service skips non-http schemes when rewriting.
+   - Never an absolute URL. A hardcoded origin bakes the authoring machine's address into the artifact; a baked-in `http://localhost:3015` is exactly the bug that broke a real share card. The service absolutizes the relative path against the real origin at serve time, so relative is both safer and sufficient. It also survives the asset moving to a vanity URL or a different host.
+   - Never root-absolute (`/assets/og.png`). Artifacts serve under `/sites/<identifier>-<uuid>/`, so a leading-slash path 404s.
+
+3. **`twitter:card` only alongside `og:image`.** The service injects it if forgotten; writing it is better form.
+
+4. **Omit `og:url` and `rel="canonical"`.** Authoring time cannot know the final URL, the service can only repair a wrong origin (never a wrong path), and unfurlers fall back to the fetched URL when `og:url` is absent. Emitting them is pure downside.
+
+5. **Internal-only deliverables** (meeting prep, deal coaching, briefs, internal dashboards) may drop the `og:image` + `twitter:card` pair; keep title and description always. Anything published `public` carries all four; the asset-manager publish flow checks this before uploading a public website.
+
+## Rendering the share image
+
+The brand-kit renderer already has a 1200×630 OG canvas; the image is a two-command chain (no new tooling):
+
+```bash
+mkdir -p <deliverable-dir>/assets
+python3 <skill-dir>/../get-brand-components/scripts/render_kit.py --kit <slug> \
+  --spec og-spec.json --format og --out og-frame.html
+python3 <skill-dir>/../get-brand-components/scripts/render.py \
+  --file og-frame.html --out <deliverable-dir>/assets/og.png --width 1200 --height 630 --scale 1
+```
+
+`og-spec.json` is a single `hero` block carrying the deliverable's headline and a one-line subhead, written fresh from the deliverable (not pasted from internal notes) and held to editorial rules:
+
+```json
+{"title": "<headline>", "blocks": [{"type": "hero", "title": "<headline>", "lead": "<one-line subhead>"}]}
+```
+
+Delete `og-frame.html` afterwards; only `assets/og.png` ships. The `get-brand-components` skill renders this automatically when a deliverable is headed for publishing (see its Output formats section); other variants (square, story, email) stay ask-first.
+
+## The one sanctioned sibling file
+
+A relative `og:image` is not an external dependency: the page itself never fetches it, only crawlers do, so it does not violate a format's self-containment rule. It does turn a single-file deliverable into a two-file folder (`index.html` + `assets/og.png`). That is the one sanctioned sibling file, and the asset-manager upload scripts already handle folders.
+
+## Where cards actually render
+
+Only **published + `public`** website assets unfurl. `workspace` and `only_me` sit behind email verification, and share links are crawler-blocked, so perfect tags on those tiers produce no card. Author the tags everywhere anyway: flipping an asset public later then needs no re-edit, and the asset-manager flow fills the image gap at publish time.

--- a/skills/shared/social-meta.md
+++ b/skills/shared/social-meta.md
@@ -28,16 +28,18 @@ Immediately after `<title>` in the `<head>`:
 
 1. **`og:title` and `og:description` go on every HTML deliverable.** They cost nothing and survive a later privacy flip to `public` without a re-edit. This copy renders on the social card, so it is reader-facing: hold it to [editorial-rules.md](editorial-rules.md) even though the mechanical lint cannot see attribute text (its text extraction strips tags). No unfilled placeholders, no internal framing, no em dashes.
 
-2. **`og:image` is always a RELATIVE path** (`assets/og.png`), never anything else:
+2. **`og:image` is always AUTHORED as a RELATIVE path** (`assets/og.png`), never anything else:
    - Never a `data:` URI. Every unfurler ignores it, and the service skips non-http schemes when rewriting.
    - Never an absolute URL. A hardcoded origin bakes the authoring machine's address into the artifact; a baked-in `http://localhost:3015` is exactly the bug that broke a real share card. The service absolutizes the relative path against the real origin at serve time, so relative is both safer and sufficient. It also survives the asset moving to a vanity URL or a different host.
    - Never root-absolute (`/assets/og.png`). Artifacts serve under `/sites/<identifier>-<uuid>/`, so a leading-slash path 404s.
 
-3. **`twitter:card` only alongside `og:image`.** The service injects it if forgotten; writing it is better form.
+3. **Hard rule: the og:image a crawler sees MUST be an absolute URL.** Unfurlers only load a full `https://` image URL from the bytes they fetch; a relative path in the served page means no card. On the artifact service the relative path from rule 2 satisfies this, because the service rewrites it to a full URL at serve time. Any host that serves files verbatim (Vercel, S3, any static server) does no rewriting: after the first deploy returns the URL, set og:image to `<url>/assets/og.png` and deploy again. That edit happens after the review gate, so a re-lint of that hosted copy failing the absolute-URL check is expected.
 
-4. **Omit `og:url` and `rel="canonical"`.** Authoring time cannot know the final URL, the service can only repair a wrong origin (never a wrong path), and unfurlers fall back to the fetched URL when `og:url` is absent. Emitting them is pure downside.
+4. **`twitter:card` only alongside `og:image`.** The service injects it if forgotten; writing it is better form.
 
-5. **Internal-only deliverables** (meeting prep, deal coaching, briefs, internal dashboards) may drop the `og:image` + `twitter:card` pair; keep title and description always. Anything published `public` carries all four; the asset-manager publish flow checks this before uploading a public website.
+5. **Omit `og:url` and `rel="canonical"`.** Authoring time cannot know the final URL, the service can only repair a wrong origin (never a wrong path), and unfurlers fall back to the fetched URL when `og:url` is absent. Emitting them is pure downside.
+
+6. **Internal-only deliverables** (meeting prep, deal coaching, briefs, internal dashboards) may drop the `og:image` + `twitter:card` pair; keep title and description always. Anything published `public` carries all four; the asset-manager publish flow checks this before uploading a public website.
 
 ## Rendering the share image
 

--- a/skills/train/references/html-scaffold.md
+++ b/skills/train/references/html-scaffold.md
@@ -1,6 +1,6 @@
 # Onboarding GTM Primer — HTML Scaffold (gated slide lesson)
 
-A single self-contained HTML file. Inline all CSS and JS; the only external dependency is Google Fonts (or the brand kit's `@font-face`). The primer is a **gated slide lesson**: fixed-viewport slides, a progress-dot rail, per-slide checkpoints that unlock the Next button, interactive tab selectors (personas, competitors, proof lenses), and a scored completion slide.
+A single self-contained HTML file. Inline all CSS and JS; the only external dependency is Google Fonts (or the brand kit's `@font-face`). The head carries the social share block (og:title + og:description always, relative og:image when published; canonical block in [../../shared/social-meta.md](../../shared/social-meta.md)). The primer is a **gated slide lesson**: fixed-viewport slides, a progress-dot rail, per-slide checkpoints that unlock the Next button, interactive tab selectors (personas, competitors, proof lenses), and a scored completion slide.
 
 **Styling comes from the workspace company's brand kit.** Inline the kit's `tokens.css` (`:root` + `@font-face`) and `../get-brand-components/assets/kit_base.css`, then map the component classes below onto the kit's `--brand-*` variables. The classes here are structural; the brand kit supplies color, type, radius, and signature moves. (When authoring a cleaned `:root`, do not paste comment lines from the kit that contain em/en-dashes; the lint rejects them.)
 

--- a/skills/win-loss-report/references/html-architecture.md
+++ b/skills/win-loss-report/references/html-architecture.md
@@ -25,6 +25,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Win/Loss Report - [Period]</title>
+  <!-- Social share (link unfurl) metadata -->
+  <meta property="og:title" content="Win/Loss Report: [Period]">
+  <meta property="og:description" content="[1-2 sentence summary a stranger understands]">
+  <meta property="og:image" content="assets/og.png">
+  <meta name="twitter:card" content="summary_large_image">
   <!-- Brand kit font link (Typekit or Google Fonts) -->
   <style>
     :root { /* brand kit tokens + chart variables */ }


### PR DESCRIPTION
Links to generated artifacts unfurl with a bare page title at best, because none of the HTML scaffolds emit Open Graph tags. The artifact service now lets social crawlers (Slack, LinkedIn, X, WhatsApp) fetch public sites and turns a relative og:image into a full URL at serve time, so the missing half is on this side.

What changed:

- New `skills/shared/social-meta.md` with the canonical head block and the rules: og:title and og:description on every deliverable, og:image always a relative path like `assets/og.png` (never a data: URI, never an absolute URL), and no og:url or canonical.
- Every HTML scaffold now carries that block in its head.
- The shared lint checks it. Missing og:title or og:description fails; a broken og:image (data: URI, absolute URL, unfilled placeholder) fails; a missing og:image only warns, since the image matters at publish time and the publish flow is where the hard check lives.
- get-brand-components already had a 1200x630 `og` canvas behind an ask-first prompt. It now renders the share image automatically when a deliverable is headed for publishing, and `render_kit.py` gained optional `--og-desc` / `--og-image` flags. Other format variants stay ask-first.
- asset-manager now explains that only `public` assets unfurl (workspace and only_me sit behind email verification) and checks the tags before uploading a public website or flipping one to public.
- Plugin and marketplace bumped to 2.7.0.

Tested: lint fixtures for each new check (missing tags, data:/absolute/root-absolute og:image, unfilled placeholders, og:url present), a verbatim scaffold copy tripping the placeholder check, and the render chain producing a real 1200x630 PNG.
